### PR TITLE
Deactivated blog pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,12 +26,7 @@ const config = {
           // Please change this to your repo.
           editUrl: 'https://github.com/autobrr/autobrr.com/tree/main/',
         },
-        blog: {
-          showReadingTime: true,
-          // Please change this to your repo.
-          editUrl:
-            'https://github.com/autobrr/autobrr.com/tree/main/',
-        },
+        blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },


### PR DESCRIPTION
The blog sample is currently active and visible on https://autobrr.com/blog
This deactivates it without deleting the blog folder, and throws a "Page Not Found" if someone were to stumble upon it.