### PR TITLE
fix for autobrr.service

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -120,7 +120,7 @@ Then fill it with the following service definition
 ```systemd title="/etc/systemd/system/autobrr.service"
 [Unit]
 Description=autobrr service for username
-After=syslog.target network.target
+After=syslog.target network-online.target
 [Service]
 Type=simple
 User=username


### PR DESCRIPTION
Changed `syslog.target network.target` to `syslog.target network-online.target`

Reported by tijuco.