### PR TITLE
Dynamic color change in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,7 +62,6 @@ const config = {
         defaultMode: 'dark',
       },
       footer: {
-        style: 'dark',
         links: [
           {
             title: 'Docs',


### PR DESCRIPTION
Right now the footer color is blue in both dark and light mode. It looks great in light mode, but weird in dark mode. This change makes it better looking in dark mode, but makes it whiteish in light mode. Since dark mode is now default, this will make the docs look better in general in my opinion.