### PR TITLE
docs: huno, discord warning, filter prio

### DIFF
--- a/docs/configuration/indexers.md
+++ b/docs/configuration/indexers.md
@@ -24,8 +24,6 @@ import IpApproval from '/snippets/ipapproval.mdx';
 
 <Indexers/>
 
-<IpApproval/>
-
 ## Setup
 
 Go to `Settings > Indexers` to add indexers.

--- a/docs/configuration/indexers.md
+++ b/docs/configuration/indexers.md
@@ -20,10 +20,11 @@ If you want more indexers added please either create a PR for it, post a comment
 :::
 
 import Indexers from '/snippets/indexers.mdx';
-
 import IpApproval from '/snippets/ipapproval.mdx';
 
 <Indexers/>
+
+<IpApproval/>
 
 ## Setup
 

--- a/docs/configuration/notifications.md
+++ b/docs/configuration/notifications.md
@@ -35,6 +35,11 @@ autobrr can send notifications on the following events:
 
 ## Discord
 
+:::warning
+There is currently a bug when using the `Push Error` event.
+It may leak your Download Client API/passkeys to the Discord channel. Keep that in mind if your Discord channel is accessible by others.
+:::
+
 To set up notifications for Discord, head to `Settings > Notifications`.
 
 1. Click **Add new**.

--- a/docs/filters/actions.md
+++ b/docs/filters/actions.md
@@ -11,7 +11,7 @@ keywords:
     Deluge,
     Transmission,
     Radarr,
-    Sonarr,wt
+    Sonarr,
     Lidarr,
     Whisparr,
     Webhook,

--- a/docs/filters/basics.md
+++ b/docs/filters/basics.md
@@ -60,7 +60,7 @@ For TV and movies it's advised to use filters like `resolution`, `source` and `c
 | **Max. size**         | Maximum torrent size allowed. Supports units such as MB, MiB, GB, etc.           |                      |
 | **Min. size**         | Minimum torrent size allowed. Supports units such as MB, MiB, GB, etc.           |                      |
 | **Delay**             | Number of seconds to wait before running actions.                                | 0                    |
-| **Priority**          | Filters are checked in order of priority. Positive and negative numbers allowed. | 0                    |
+| **Priority**          | Filters are checked in order of priority. Positive and negative numbers allowed. Higher number = higher priority. | 0                    |
 | **Max downloads**     | Number of max downloads as specified by the respective unit.                     | 0 (which means +Inf) |
 | **Max downloads per** | The unit of time for counting the maximum downloads per filter.                  |                      |
 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -129,7 +129,7 @@ sudo systemctl status autobrr@USERNAME.service
 
 It's recommended to run it behind a reverse proxy like nginx in order to get TLS, more robust authentication mechanisms and other similar benefits.
 
-This is an nginx example that should work for most:
+### Nginx
 
 ```nginx
 location /autobrr/ {
@@ -143,6 +143,26 @@ location /autobrr/ {
     rewrite ^/autobrr/(.*) /$1 break;
 }
 ```
+
+### Caddy
+
+```nginx
+example.com/autobrr/* {
+    uri strip_prefix /autobrr
+    reverse_proxy :7474
+}
+
+example.com {
+    reverse_proxy /radarr*      localhost:7878
+    reverse_proxy /sonarr*      localhost:8989
+    reverse_proxy /nzbget*      localhost:6789
+    reverse_proxy /prowlarr*     localhost:9696
+    reverse_proxy /tautulli*     localhost:8181
+    reverse_proxy /lidarr*      localhost:8686
+    reverse_proxy /notifiarr*    localhost:5454
+}
+```
+
 
 :::info
 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -129,6 +129,8 @@ sudo systemctl status autobrr@USERNAME.service
 
 It's recommended to run it behind a reverse proxy like nginx in order to get TLS, more robust authentication mechanisms and other similar benefits.
 
+This is an nginx example that should work for most:
+
 ```nginx
 location /autobrr/ {
     proxy_pass              http://127.0.0.1:7474;

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -129,8 +129,6 @@ sudo systemctl status autobrr@USERNAME.service
 
 It's recommended to run it behind a reverse proxy like nginx in order to get TLS, more robust authentication mechanisms and other similar benefits.
 
-### Nginx
-
 ```nginx
 location /autobrr/ {
     proxy_pass              http://127.0.0.1:7474;
@@ -143,26 +141,6 @@ location /autobrr/ {
     rewrite ^/autobrr/(.*) /$1 break;
 }
 ```
-
-### Caddy
-
-```nginx
-example.com/autobrr/* {
-    uri strip_prefix /autobrr
-    reverse_proxy :7474
-}
-
-example.com {
-    reverse_proxy /radarr*      localhost:7878
-    reverse_proxy /sonarr*      localhost:8989
-    reverse_proxy /nzbget*      localhost:6789
-    reverse_proxy /prowlarr*     localhost:9696
-    reverse_proxy /tautulli*     localhost:8181
-    reverse_proxy /lidarr*      localhost:8686
-    reverse_proxy /notifiarr*    localhost:5454
-}
-```
-
 
 :::info
 

--- a/snippets/indexers.mdx
+++ b/snippets/indexers.mdx
@@ -19,6 +19,7 @@
 - Hebits
 - HD-Space
 - HD-Torrents
+- Huno
 - ImmortalSeed
 - IPTorrents
 - Milkie


### PR DESCRIPTION
- Added Huno to list of supported indexers
- Added warning regarding Discord webhooks
- Added info about filter priority logic