### PR TITLE
docs: add sections in download clients for shared seedboxes

### DIFF
--- a/docs/configuration/download-clients.md
+++ b/docs/configuration/download-clients.md
@@ -91,6 +91,12 @@ With **Docker** / containers make sure autobrr and qBittorrent share the same ne
 - Username: `<username>`
 - Password: `<password>`
 
+### Shared Seedboxes
+
+import SharedqBittorrent from '/snippets/shared-download-clients/qbittorrent.mdx';
+
+<SharedqBittorrent />
+
 ### qBittorrent rules
 
 You can define some basic rules which can improve your performance for racing etc.
@@ -151,6 +157,12 @@ With **Docker** / containers make sure autobrr and Deluge share the same network
 - Username: `<username>`
 - Password: `<password>`
 
+### Shared Seedboxes
+
+import SharedDeluge from '/snippets/shared-download-clients/deluge.mdx';
+
+<SharedDeluge />
+
 ### Deluge rules
 
 You can define some basic rules which can improve your performance for racing etc.
@@ -196,6 +208,11 @@ With **Docker** / containers make sure autobrr and rTorrent share the same netwo
 
 - Host: `http://user:password@rtorrent/rutorrent/plugins/httprpc/action.php`
 
+### Shared Seedboxes
+
+import SharedrTorrent from '/snippets/shared-download-clients/rtorrent.mdx';
+
+<SharedrTorrent />
 
 ## Transmission
 
@@ -245,6 +262,12 @@ With **Docker** / containers make sure autobrr and Transmission share the same n
 - Username: `<username>`
 - Password: `<password>`
 
+### Shared Seedboxes
+
+import SharedTransmission from '/snippets/shared-download-clients/transmission.mdx';
+
+<SharedTransmission />
+
 ## Sonarr
 
 You can run autobrr and Sonarr apps on the following setups.
@@ -281,6 +304,12 @@ With **Docker** / containers make sure autobrr and Sonarr share the same network
 
 - Host: `http://sonarr:8989`
 - API Key: `API KEY`
+
+### Shared Seedboxes
+
+import SharedSonarr from '/snippets/shared-download-clients/sonarr.mdx';
+
+<SharedSonarr />
 
 ## Radarr
 
@@ -319,9 +348,21 @@ With **Docker** / containers make sure autobrr and Radarr share the same network
 - Host: `http://radarr:7878`
 - API Key: `API KEY`
 
+### Shared Seedboxes
+
+import SharedRadarr from '/snippets/shared-download-clients/radarr.mdx';
+
+<SharedRadarr />
+
 ## Lidarr
 
 See Radarr and Sonarr but port `8686`.
+
+### Shared Seedboxes
+
+import SharedLidarr from '/snippets/shared-download-clients/lidarr.mdx';
+
+<SharedLidarr />
 
 ## Whisparr
 

--- a/docs/configuration/download-clients.md
+++ b/docs/configuration/download-clients.md
@@ -57,7 +57,7 @@ You can run autobrr and qBittorrent on the following setups.
 - Remote server
 - Docker / container
 
-### Local
+### Local {#qbittorrent-local}
 
 For a local client, meaning autobrr and qBittorrent **on the same server** then this should work. Check qBittorrent settings to get the `WEBUI_PORT`.
 
@@ -66,7 +66,7 @@ For a local client, meaning autobrr and qBittorrent **on the same server** then 
 - Username: `<username>`
 - Password: `<password>`
 
-### Remote
+### Remote {#qbittorrent-remote}
 
 For a remote client, meaning autobrr and qBittorrent are **not on the same server** then things might be a bit different.
 
@@ -82,7 +82,7 @@ Some setups like **Swizzin** requires to also use **Basic Auth** when connecting
 - Username: `<username>`
 - Password: `<password>`
 
-### Docker
+### Docker {#qbittorrent-docker}
 
 With **Docker** / containers make sure autobrr and qBittorrent share the same network to be able to use the `container_name` as address.
 
@@ -91,7 +91,7 @@ With **Docker** / containers make sure autobrr and qBittorrent share the same ne
 - Username: `<username>`
 - Password: `<password>`
 
-### Shared Seedboxes
+### Shared Seedboxes {#qbittorrent-shared-seedboxes}
 
 import SharedqBittorrent from '/snippets/shared-download-clients/qbittorrent.mdx';
 
@@ -121,7 +121,7 @@ Deluge is split into two versions:
 
 Select `TYPE` then set these.
 
-### Local
+### Local {#deluge-local}
 
 For a local client, meaning autobrr and Deluge **on the same server** then this should work. Check Deluge settings to get the `DAEMON_PORT`.
 
@@ -131,7 +131,7 @@ For a local client, meaning autobrr and Deluge **on the same server** then this 
 - Username: `<username>`
 - Password: `<password>`
 
-### Remote
+### Remote {#deluge-remote}
 
 For a remote client, meaning autobrr and Deluge are **not on the same server** then things might be a bit different.
 
@@ -147,7 +147,7 @@ Some setups like **Swizzin** requires to also use **Basic Auth** when connecting
 - Username: `<username>`
 - Password: `<password>`
 
-### Docker
+### Docker {#deluge-docker}
 
 With **Docker** / containers make sure autobrr and Deluge share the same network to be able to use the `container_name` as address.
 
@@ -157,7 +157,7 @@ With **Docker** / containers make sure autobrr and Deluge share the same network
 - Username: `<username>`
 - Password: `<password>`
 
-### Shared Seedboxes
+### Shared Seedboxes {#deluge-shared-seedboxes}
 
 import SharedDeluge from '/snippets/shared-download-clients/deluge.mdx';
 
@@ -178,7 +178,7 @@ You can run autobrr and rTorrent / ruTorrent on the following setups.
 - Remote server
 - Docker / container
 
-### Local
+### Local {#rtorrent-local}
 
 For a local client, meaning autobrr and ruTorrent **on the same server** try these.
 
@@ -192,20 +192,20 @@ If you are on a shared seedbox you might need your username in the url like:
 
 - Host: `http://user:password@localhost/USERNAME/rutorrent/plugins/httprpc/action.php`
 
-### Remote
+### Remote {#rtorrent-remote}
 
 For a remote client, meaning autobrr and rTorrent are **not on the same server** then things might be a bit different.
 
 - Host: `http://user:password@EXTERNAL_IP/rutorrent/plugins/httprpc/action.php`
 - Host: `http://user:password@mydomain.com/rutorrent/plugins/httprpc/action.php`
 
-### Docker
+### Docker {#rtorrent-docker}
 
 With **Docker** / containers make sure autobrr and rTorrent share the same network to be able to use the `container_name` as address.
 
 - Host: `http://user:password@rtorrent/rutorrent/plugins/httprpc/action.php`
 
-### Shared Seedboxes
+### Shared Seedboxes {#rtorrent-shared-seedboxes}
 
 import SharedrTorrent from '/snippets/shared-download-clients/rtorrent.mdx';
 
@@ -219,7 +219,7 @@ You can run autobrr and Transmission on the following setups.
 - Remote server
 - Docker / container
 
-### Local
+### Local {#transmission-local}
 
 For a local client, meaning autobrr and Transmission **on the same server** then this should work. Check Transmission settings to get the `WEBUI_PORT`. Default is 9091.
 
@@ -229,7 +229,7 @@ For a local client, meaning autobrr and Transmission **on the same server** then
 - Username: `<username>`
 - Password: `<password>`
 
-### Remote
+### Remote {#transmission-remote}
 
 For a remote client, meaning autobrr and Transmission are **not on the same server** then things might be a bit different.
 
@@ -249,7 +249,7 @@ HTTPS / TLS
 - Username: `<username>`
 - Password: `<password>`
 
-### Docker
+### Docker {#transmission-docker}
 
 With **Docker** / containers make sure autobrr and Transmission share the same network to be able to use the `container_name` as address.
 
@@ -259,7 +259,7 @@ With **Docker** / containers make sure autobrr and Transmission share the same n
 - Username: `<username>`
 - Password: `<password>`
 
-### Shared Seedboxes
+### Shared Seedboxes {#transmission-shared-seedboxes}
 
 import SharedTransmission from '/snippets/shared-download-clients/transmission.mdx';
 
@@ -273,7 +273,7 @@ You can run autobrr and Sonarr apps on the following setups.
 - Remote server
 - Docker / container
 
-### Local
+### Local {#sonarr-local}
 
 For a local client, meaning autobrr and Sonarr **on the same server** then this should work.
 
@@ -284,7 +284,7 @@ On **Swizzin** or if you are running Sonarr with a baseUrl set that in the url a
 
 - Host: `http://127.0.0.1:8989/sonarr`
 
-### Remote
+### Remote {#sonarr-remote}
 
 For a remote client, meaning autobrr and Sonarr are **not on the same server** then things might be a bit different.
 
@@ -295,14 +295,14 @@ On **Swizzin** or if you are running Sonarr with a baseUrl set that in the url a
 
 - Host: `https://mydomain.com/sonarr`
 
-### Docker
+### Docker {#sonarr-docker}
 
 With **Docker** / containers make sure autobrr and Sonarr share the same network to be able to use the `container_name` as address.
 
 - Host: `http://sonarr:8989`
 - API Key: `API KEY`
 
-### Shared Seedboxes
+### Shared Seedboxes {#sonarr-shared-seedboxes}
 
 import SharedSonarr from '/snippets/shared-download-clients/sonarr.mdx';
 
@@ -316,7 +316,7 @@ You can run autobrr and Radarr apps on the following setups.
 - Remote server
 - Docker / container
 
-### Local
+### Local {#radarr-local}
 
 For a local client, meaning autobrr and Radarr **on the same server** then this should work.
 
@@ -327,7 +327,7 @@ On **Swizzin** or if you are running Radarr with a baseUrl set that in the url a
 
 - Host: `http://127.0.0.1:7878/radarr`
 
-### Remote
+### Remote {#radarr-local}
 
 For a remote client, meaning autobrr and Radarr are **not on the same server** then things might be a bit different.
 
@@ -338,14 +338,14 @@ On **Swizzin** or if you are running Radarr with a baseUrl set that in the url a
 
 - Host: `https://mydomain.com/radarr`
 
-### Docker
+### Docker {#radarr-docker}
 
 With **Docker** / containers make sure autobrr and Radarr share the same network to be able to use the `container_name` as address.
 
 - Host: `http://radarr:7878`
 - API Key: `API KEY`
 
-### Shared Seedboxes
+### Shared Seedboxes {#radarr-shared-seedboxes}
 
 import SharedRadarr from '/snippets/shared-download-clients/radarr.mdx';
 
@@ -355,7 +355,7 @@ import SharedRadarr from '/snippets/shared-download-clients/radarr.mdx';
 
 See Radarr and Sonarr but port `8686`.
 
-### Shared Seedboxes
+### Shared Seedboxes {#lidarr-shared-seedboxes}
 
 import SharedLidarr from '/snippets/shared-download-clients/lidarr.mdx';
 

--- a/docs/configuration/download-clients.md
+++ b/docs/configuration/download-clients.md
@@ -57,7 +57,7 @@ You can run autobrr and qBittorrent on the following setups.
 - Remote server
 - Docker / container
 
-#### Local
+### Local
 
 For a local client, meaning autobrr and qBittorrent **on the same server** then this should work. Check qBittorrent settings to get the `WEBUI_PORT`.
 
@@ -66,7 +66,7 @@ For a local client, meaning autobrr and qBittorrent **on the same server** then 
 - Username: `<username>`
 - Password: `<password>`
 
-#### Remote
+### Remote
 
 For a remote client, meaning autobrr and qBittorrent are **not on the same server** then things might be a bit different.
 
@@ -82,7 +82,7 @@ Some setups like **Swizzin** requires to also use **Basic Auth** when connecting
 - Username: `<username>`
 - Password: `<password>`
 
-#### Docker
+### Docker
 
 With **Docker** / containers make sure autobrr and qBittorrent share the same network to be able to use the `container_name` as address.
 
@@ -97,7 +97,7 @@ import SharedqBittorrent from '/snippets/shared-download-clients/qbittorrent.mdx
 
 <SharedqBittorrent />
 
-### qBittorrent rules
+## qBittorrent rules
 
 You can define some basic rules which can improve your performance for racing etc.
 
@@ -121,7 +121,7 @@ Deluge is split into two versions:
 
 Select `TYPE` then set these.
 
-#### Local
+### Local
 
 For a local client, meaning autobrr and Deluge **on the same server** then this should work. Check Deluge settings to get the `DAEMON_PORT`.
 
@@ -131,7 +131,7 @@ For a local client, meaning autobrr and Deluge **on the same server** then this 
 - Username: `<username>`
 - Password: `<password>`
 
-#### Remote
+### Remote
 
 For a remote client, meaning autobrr and Deluge are **not on the same server** then things might be a bit different.
 
@@ -147,7 +147,7 @@ Some setups like **Swizzin** requires to also use **Basic Auth** when connecting
 - Username: `<username>`
 - Password: `<password>`
 
-#### Docker
+### Docker
 
 With **Docker** / containers make sure autobrr and Deluge share the same network to be able to use the `container_name` as address.
 
@@ -163,7 +163,7 @@ import SharedDeluge from '/snippets/shared-download-clients/deluge.mdx';
 
 <SharedDeluge />
 
-### Deluge rules
+## Deluge rules
 
 You can define some basic rules which can improve your performance for racing etc.
 
@@ -178,7 +178,7 @@ You can run autobrr and rTorrent / ruTorrent on the following setups.
 - Remote server
 - Docker / container
 
-#### Local
+### Local
 
 For a local client, meaning autobrr and ruTorrent **on the same server** try these.
 
@@ -192,17 +192,14 @@ If you are on a shared seedbox you might need your username in the url like:
 
 - Host: `http://user:password@localhost/USERNAME/rutorrent/plugins/httprpc/action.php`
 
-#### Remote
-
+### Remote
 
 For a remote client, meaning autobrr and rTorrent are **not on the same server** then things might be a bit different.
-
 
 - Host: `http://user:password@EXTERNAL_IP/rutorrent/plugins/httprpc/action.php`
 - Host: `http://user:password@mydomain.com/rutorrent/plugins/httprpc/action.php`
 
-#### Docker
-
+### Docker
 
 With **Docker** / containers make sure autobrr and rTorrent share the same network to be able to use the `container_name` as address.
 
@@ -222,7 +219,7 @@ You can run autobrr and Transmission on the following setups.
 - Remote server
 - Docker / container
 
-#### Local
+### Local
 
 For a local client, meaning autobrr and Transmission **on the same server** then this should work. Check Transmission settings to get the `WEBUI_PORT`. Default is 9091.
 
@@ -232,7 +229,7 @@ For a local client, meaning autobrr and Transmission **on the same server** then
 - Username: `<username>`
 - Password: `<password>`
 
-#### Remote
+### Remote
 
 For a remote client, meaning autobrr and Transmission are **not on the same server** then things might be a bit different.
 
@@ -252,7 +249,7 @@ HTTPS / TLS
 - Username: `<username>`
 - Password: `<password>`
 
-#### Docker
+### Docker
 
 With **Docker** / containers make sure autobrr and Transmission share the same network to be able to use the `container_name` as address.
 
@@ -276,9 +273,9 @@ You can run autobrr and Sonarr apps on the following setups.
 - Remote server
 - Docker / container
 
-#### Local
+### Local
 
-For a local client, meaning autobrr and Sonarr **on the same server** then this should work. 
+For a local client, meaning autobrr and Sonarr **on the same server** then this should work.
 
 - Host: `http://127.0.0.1:8989`
 - API Key: `API KEY`
@@ -287,7 +284,7 @@ On **Swizzin** or if you are running Sonarr with a baseUrl set that in the url a
 
 - Host: `http://127.0.0.1:8989/sonarr`
 
-#### Remote
+### Remote
 
 For a remote client, meaning autobrr and Sonarr are **not on the same server** then things might be a bit different.
 
@@ -298,7 +295,7 @@ On **Swizzin** or if you are running Sonarr with a baseUrl set that in the url a
 
 - Host: `https://mydomain.com/sonarr`
 
-#### Docker
+### Docker
 
 With **Docker** / containers make sure autobrr and Sonarr share the same network to be able to use the `container_name` as address.
 
@@ -319,9 +316,9 @@ You can run autobrr and Radarr apps on the following setups.
 - Remote server
 - Docker / container
 
-#### Local
+### Local
 
-For a local client, meaning autobrr and Radarr **on the same server** then this should work. 
+For a local client, meaning autobrr and Radarr **on the same server** then this should work.
 
 - Host: `http://127.0.0.1:7878`
 - API Key: `API KEY`
@@ -330,7 +327,7 @@ On **Swizzin** or if you are running Radarr with a baseUrl set that in the url a
 
 - Host: `http://127.0.0.1:7878/radarr`
 
-#### Remote
+### Remote
 
 For a remote client, meaning autobrr and Radarr are **not on the same server** then things might be a bit different.
 
@@ -341,7 +338,7 @@ On **Swizzin** or if you are running Radarr with a baseUrl set that in the url a
 
 - Host: `https://mydomain.com/radarr`
 
-#### Docker
+### Docker
 
 With **Docker** / containers make sure autobrr and Radarr share the same network to be able to use the `container_name` as address.
 

--- a/snippets/downloadclients.mdx
+++ b/snippets/downloadclients.mdx
@@ -42,7 +42,7 @@ Password: <password>
 ```
 Host: Takes an IP or URL with http(s), eg http://111.111.111.111:1234 or http://server.test/radarr
 API key: <API key>
-Basic auth: Disabled by default.
+Basic Auth: Disabled by default.
 Username: <username>
 Password: <password>
 

--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -5,7 +5,17 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-deluge" label="Ultra.cc">
 
-- Host: `<servername>.usbx.me`
+- Host: `<hostname>.usbx.me`
+- Port: `DAEMON_PORT`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
+<TabItem value="seedhost-deluge" label="Seedhost.eu">
+
+- Host: `<hostname>.seedhost.eu`
 - Port: `DAEMON_PORT`
 - TLS: Enabled
 - Username: `<username>`

--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -13,4 +13,21 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-deluge" label="Hostingby.design">
+
+```shell
+# Bind to 0.0.0.0 to enable remote connections
+box stop deluge-web
+sed -i 's/127.0.0.1/0.0.0.0/g' ~/.config/deluge/web.conf
+box start deluge-web
+```
+
+- Host: `<hostname>.itsby.design`
+- Port: `DAEMON_PORT`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -23,6 +23,22 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="ferealhosting-deluge" label="Feralhosting">
+
+
+```shell
+# Grab credentials via SSH
+printf "10.0.0.1\n$(hostname -f)\n$(whoami)\n$(sed -rn 's/(.*)"daemon_port": (.*),/\2/p' ~/.config/deluge/core.conf)\n$(sed -rn "s/$(whoami):(.*):(.*)/\1/p" ~/.config/deluge/auth)\n"
+```
+
+- Host: `<hostname>.feralhosting.com`
+- Port: `DAEMON_PORT`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 <TabItem value="hbd-deluge" label="Hostingby.design">
 
 ```shell

--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -1,0 +1,16 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-deluge" label="Ultra.cc">
+
+- Host: `<servername>.usbx.me`
+- Port: `DAEMON_PORT`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/lidarr.mdx
+++ b/snippets/shared-download-clients/lidarr.mdx
@@ -19,6 +19,16 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="feralhosting-lidarr" label="Feralhosting">
+
+- Host: `http://<hostname>.feralhosting.com:<port>/<username>/lidarr/`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 <TabItem value="hbd-lidarr" label="Hostingby.design">
 
 - Host: `https://<hostname>.itsby.design/lidarr`

--- a/snippets/shared-download-clients/lidarr.mdx
+++ b/snippets/shared-download-clients/lidarr.mdx
@@ -19,4 +19,14 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-lidarr" label="Hostingby.design">
+
+- Host: `https://<hostname>.itsby.design/lidarr`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/lidarr.mdx
+++ b/snippets/shared-download-clients/lidarr.mdx
@@ -1,0 +1,22 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-lidarr" label="Ultra.cc">
+
+- Host: `https://<username>.<servername>.usbx.me/lidarr`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+<TabItem value="seedhost-lidarr" label="Seedhost.eu">
+
+- Host: `https://<username>.<servername>.usbx.me/lidarr`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/lidarr.mdx
+++ b/snippets/shared-download-clients/lidarr.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-lidarr" label="Ultra.cc">
 
-- Host: `https://<username>.<servername>.usbx.me/lidarr`
+- Host: `https://<username>.<hostname>.usbx.me/lidarr`
 - API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="seedhost-lidarr" label="Seedhost.eu">
 
-- Host: `https://<username>.<servername>.usbx.me/lidarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/lidarr`
 - API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 

--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -23,4 +23,14 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-qbittorrent" label="Hostingby.design">
+
+- Host `http://<hostname.io>:<qbittorrent-webui-port>`
+- TLS: Disabled
+- Username: `<username>`
+- Password: `<password>`
+- Basic auth: Disabled
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 - TLS: Enabled
 - Username: `<username>`
 - Password: `<password>`
-- Basic auth: Disabled
+- Basic Auth: Disabled
 
 </TabItem>
 
@@ -19,17 +19,19 @@ import TabItem from "@theme/TabItem";
 - TLS: Enabled
 - Username: `<username>`
 - Password: `<password>`
-- Basic auth: Disabled
+- Basic Auth: Disabled
 
 </TabItem>
 
 <TabItem value="hbd-qbittorrent" label="Hostingby.design">
 
-- Host `http://<hostname.io>:<qbittorrent-webui-port>`
-- TLS: Disabled
+- Host `https://<hostname>.itsby.design/qbittorrent`
+- TLS: Enabled
 - Username: `<username>`
 - Password: `<password>`
-- Basic auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </TabItem>
 

--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -1,0 +1,26 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-qbittorrent" label="Ultra.cc">
+
+- Host: `https://<username>.<servername>.usbx.me/qbittorrent`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+- Basic auth: Disabled
+
+</TabItem>
+
+<TabItem value="seedhost-qbittorrent" label="Seedhost.eu">
+
+- Host: `https://<servername>/<username>/qbittorrent/`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+- Basic auth: Disabled
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-qbittorrent" label="Ultra.cc">
 
-- Host: `https://<username>.<servername>.usbx.me/qbittorrent`
+- Host: `https://<username>.<hostname>.usbx.me/qbittorrent`
 - TLS: Enabled
 - Username: `<username>`
 - Password: `<password>`
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="seedhost-qbittorrent" label="Seedhost.eu">
 
-- Host: `https://<servername>/<username>/qbittorrent/`
+- Host: `https://<hostname>.seedhost.eu/qbittorrent/`
 - TLS: Enabled
 - Username: `<username>`
 - Password: `<password>`

--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -23,6 +23,16 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="feralhosting-qbittorrent" label="Feralhosting">
+
+- Host `http://<username>.argus.feralhosting.com:<port>`
+- TLS: Disabled
+- Username: `<username>`
+- Password: `<password>`
+- Basic Auth: Disabled
+
+</TabItem>
+
 <TabItem value="hbd-qbittorrent" label="Hostingby.design">
 
 - Host `https://<hostname>.itsby.design/qbittorrent`

--- a/snippets/shared-download-clients/radarr.mdx
+++ b/snippets/shared-download-clients/radarr.mdx
@@ -19,4 +19,14 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-radarr" label="Hostingby.design">
+
+- Host: `https://<hostname>.itsby.design/radarr`
+- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/radarr.mdx
+++ b/snippets/shared-download-clients/radarr.mdx
@@ -1,0 +1,22 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-radarr" label="Ultra.cc">
+
+- Host: `https://<username>.<servername>.usbx.me/radarr`
+- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+<TabItem value="seedhost-radarr" label="Seedhost.eu">
+
+- Host: `https://<username>.<servername>.usbx.me/radarr`
+- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/radarr.mdx
+++ b/snippets/shared-download-clients/radarr.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-radarr" label="Ultra.cc">
 
-- Host: `https://<username>.<servername>.usbx.me/radarr`
+- Host: `https://<username>.<hostname>.usbx.me/radarr`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="seedhost-radarr" label="Seedhost.eu">
 
-- Host: `https://<username>.<servername>.usbx.me/radarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/radarr`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 

--- a/snippets/shared-download-clients/radarr.mdx
+++ b/snippets/shared-download-clients/radarr.mdx
@@ -7,7 +7,9 @@ import TabItem from "@theme/TabItem";
 
 - Host: `https://<username>.<hostname>.usbx.me/radarr`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </TabItem>
 
@@ -15,7 +17,19 @@ import TabItem from "@theme/TabItem";
 
 - Host: `https://<hostname>.seedhost.eu/<username>/radarr`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
+<TabItem value="feralhosting-radarr" label="Feralhosting">
+
+- Host: `http://<hostname>.feralhosting.com:<port>/<username>/radarr/`
+- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </TabItem>
 

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -19,10 +19,10 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
-<TabItem value="hbd-lidarr" label="Hostingby.design">
+<TabItem value="hbd-readarr" label="Hostingby.design">
 
-- Host: `https://<hostname>.itsby.design/lidarr`
-- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Host: `https://<hostname>.itsby.design/readarr`
+- API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Enabled
 - Username: `<username>`
 - Password: `<password>`

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -19,14 +19,4 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
-<TabItem value="hbd-readarr" label="Hostingby.design">
-
-- Host: `https://<hostname>.itsby.design/readarr`
-- API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Enabled
-- Username: `<username>`
-- Password: `<password>`
-
-</TabItem>
-
 </Tabs>

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -1,0 +1,22 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-readarr" label="Ultra.cc">
+
+- Host: `https://<username>.<servername>.usbx.me/readarr`
+- API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+<TabItem value="seedhost-readarr" label="Seedhost.eu">
+
+- Host: `https://<username>.<servername>.usbx.me/readarr`
+- API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -19,4 +19,14 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-lidarr" label="Hostingby.design">
+
+- Host: `https://<hostname>.itsby.design/lidarr`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-readarr" label="Ultra.cc">
 
-- Host: `https://<username>.<servername>.usbx.me/readarr`
+- Host: `https://<username>.<hostname>.usbx.me/readarr`
 - API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="seedhost-readarr" label="Seedhost.eu">
 
-- Host: `https://<username>.<servername>.usbx.me/readarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/readarr`
 - API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
-<TabItem value="feralhosting-rtorrent" label="Feral"> 
+<TabItem value="feralhosting-rtorrent" label="Feralhosting"> 
 
 - Host: `https://rutorrent:password@<hostname>.feralhosting.com/<username>/rtorrent/rpc`
 

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -5,13 +5,13 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-rtorrent" label="Ultra.cc">
 
-- Host: `https://<username>:<password>@<username>.<servername>.usbx.me/RPC2`
+- Host: `https://<username>:<password>@<username>.<hostname>.usbx.me/RPC2`
 
 </TabItem>
 
 <TabItem value="seedhost-rtorrent" label="Seedhost.eu"> 
 
-- Host: `https://<username>:<password>@<servername>/<username>/rutorrent/plugins/httprpc/action.php`
+- Host: `https://<username>:<password>@<hostname>.seedhost.eu/<username>/rutorrent/plugins/httprpc/action.php`
 
 </TabItem>
 

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -21,4 +21,10 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-rtorrent" label="Hostingby.design"> 
+
+- Host: `https://username:password@<hostname>.itsby.design/rutorrent/plugins/httprpc/action.php`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -1,0 +1,24 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-rtorrent" label="Ultra.cc">
+
+- Host: `https://<username>:<password>@<username>.<servername>.usbx.me/RPC2`
+
+</TabItem>
+
+<TabItem value="seedhost-rtorrent" label="Seedhost.eu"> 
+
+- Host: `https://<username>:<password>@<servername>/<username>/rutorrent/plugins/httprpc/action.php`
+
+</TabItem>
+
+<TabItem value="feralhosting-rtorrent" label="Feral"> 
+
+- Host: `https://rutorrent:password@nyx.feralhosting.com/myuser/rtorrent/rpc`
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -17,7 +17,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="feralhosting-rtorrent" label="Feral"> 
 
-- Host: `https://rutorrent:password@nyx.feralhosting.com/myuser/rtorrent/rpc`
+- Host: `https://rutorrent:password@<hostname>.feralhosting.com/<username>/rtorrent/rpc`
 
 </TabItem>
 

--- a/snippets/shared-download-clients/sonarr.mdx
+++ b/snippets/shared-download-clients/sonarr.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-sonarr" label="Ultra.cc">
 
-- Host: `https://<username>.<servername>.usbx.me/sonarr`
+- Host: `https://<username>.<hostname>.usbx.me/sonarr`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="seedhost-sonarr" label="Seedhost.eu">
 
-- Host: `https://<username>.<servername>.usbx.me/sonarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/sonarr`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 

--- a/snippets/shared-download-clients/sonarr.mdx
+++ b/snippets/shared-download-clients/sonarr.mdx
@@ -7,7 +7,9 @@ import TabItem from "@theme/TabItem";
 
 - Host: `https://<username>.<hostname>.usbx.me/sonarr`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </TabItem>
 
@@ -15,7 +17,19 @@ import TabItem from "@theme/TabItem";
 
 - Host: `https://<hostname>.seedhost.eu/<username>/sonarr`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
+<TabItem value="feralhosting-sonarr" label="Feralhosting">
+
+- Host: `http://<hostname>.feralhosting.com:<port>/<username>/sonarr/`
+- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </TabItem>
 

--- a/snippets/shared-download-clients/sonarr.mdx
+++ b/snippets/shared-download-clients/sonarr.mdx
@@ -1,0 +1,22 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-sonarr" label="Ultra.cc">
+
+- Host: `https://<username>.<servername>.usbx.me/sonarr`
+- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+<TabItem value="seedhost-sonarr" label="Seedhost.eu">
+
+- Host: `https://<username>.<servername>.usbx.me/sonarr`
+- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
+</Tabs>

--- a/snippets/shared-download-clients/sonarr.mdx
+++ b/snippets/shared-download-clients/sonarr.mdx
@@ -19,4 +19,14 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="hbd-sonarr" label="Hostingby.design">
+
+- Host: `https://<hostname>.itsby.design/sonarr`
+- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/transmission.mdx
+++ b/snippets/shared-download-clients/transmission.mdx
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 <TabItem value="ultra-transmission" label="Ultra.cc">
 
-- Host: `<username>.<servername>.usbx.me`
+- Host: `<username>.<hostname>.usbx.me`
 - Port: Transmissions' RPC Port as given in your Control Panel
 - TLS: Enabled
 - Username: `<username>`

--- a/snippets/shared-download-clients/transmission.mdx
+++ b/snippets/shared-download-clients/transmission.mdx
@@ -13,4 +13,28 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="feralhosting-transmission" label="Feralhosting">
+
+- Host: `<hostname>.feralhosting.com/<username>/transmission/rpc`
+- Port: 9091
+- TLS: Enabled
+- Password: `<password>`
+
+</TabItem>
+
+<TabItem value="seedhost-transmission" label="Seedhost.eu">
+
+```shell
+# Grab RPC Port
+echo -e "Your Transmission port: \e[31m$(grep '"rpc-port": [0-9]*' ~/.config/transmission-daemon/settings.json | awk -F ': ' '{print $2}' | awk -F ',' '{print $1}')\e[0m"
+```
+
+- Host: `<hostname>.seedhost.eu/<username>/transmission/rpc`
+- Port: `<RPC Port>`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/transmission.mdx
+++ b/snippets/shared-download-clients/transmission.mdx
@@ -1,0 +1,16 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs>
+
+<TabItem value="ultra-transmission" label="Ultra.cc">
+
+- Host: `<username>.<servername>.usbx.me`
+- Port: Transmissions' RPC Port as given in your Control Panel
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
+</Tabs>


### PR DESCRIPTION
Created the skeleton for download client sections for shared seedboxes.
Only ultra and some seedhost and feral got added so far - will do others as soon as I gathered the data.
Feel free to contribute to this PR or ping me on discord if you have data i can add.

- [x] hostingby.design qBittorrent
- [x] hostingby.design Deluge
- [x] hostingby.design rTorrent
- [x] hostingby.design Sonarr
- [x] hostingby.design Radarr
- [x] hostingby.design Lidarr
- [x] Seedhost qBittorrent
- [x] Seedhost Deluge
- [x] Seedhost rTorrent
- [x] Seedhost Sonarr
- [x] Seedhost Radarr
- [x] Seedhost Lidarr
- [x] Seedhost Readarr
- [x] Seedhost Transmission
- [x] Feral qBittorrent
- [x] Feral Deluge
- [x] Feral rTorrent
- [x] Feral Transmission
- [x] Feral Sonarr
- [x] Feral Radarr
- [x] Feral Lidarr
- [ ] swizzin.net qBittorrent
- [ ] swizzin.net Deluge
- [ ] swizzin.net rTorrent
- [ ] swizzin.net Transmission
- [ ] swizzin.net Sonarr
- [ ] swizzin.net Radarr
- [ ] swizzin.net Lidarr
- [ ] swizzin.net Readarr
- [ ] WhatBox qBittorrent
- [ ] WhatBox Deluge
- [ ] WhatBox rTorrent
- [ ] WhatBox Transmission
- [ ] WhatBox Sonarr
- [ ] WhatBox Radarr
- [ ] WhatBox Lidarr
- [ ] WhatBox Readarr
- [ ] Bytesized qBittorrent
- [ ] Bytesized Deluge
- [ ] Bytesized rTorrent
- [ ] Bytesized Transmission
- [ ] Bytesized Sonarr
- [ ] Bytesized Radarr
- [ ] Bytesized Lidarr
- [ ] Bytesized Readarr

~~- [ ] Feral Readarr~~ Not supported
~~- [ ] hostingby.design Readarr~~ Not supported
~~- [ ] hostingby.design Transmission~~ Not supported