### PR TITLE
docs: added more categories and supported indexers

### DIFF
--- a/snippets/categories/aither.mdx
+++ b/snippets/categories/aither.mdx
@@ -1,0 +1,14 @@
+<details><summary>Aither</summary>
+
+- Audiobooks
+- Ebooks & Magazines
+- Education
+- Games
+- Movie
+- Music
+- Software & Apps
+- Sport
+- TV
+- XXX
+
+</details>

--- a/snippets/categories/pixelhd.mdx
+++ b/snippets/categories/pixelhd.mdx
@@ -1,0 +1,10 @@
+<details><summary>PixelHD</summary>
+
+- PxHD Mobies
+- PxHD
+- PxEHD
+- Px4K
+- PxHDA
+- Px3D
+
+</details>

--- a/snippets/categories/ptn.mdx
+++ b/snippets/categories/ptn.mdx
@@ -1,0 +1,8 @@
+<details><summary>Piratethenet</summary>
+
+- 2160P
+- 1080P
+- 720P
+- WebRip
+
+</details>

--- a/snippets/category-snippets.mdx
+++ b/snippets/category-snippets.mdx
@@ -1,4 +1,5 @@
 import AcidLounge from "/snippets/categories/acidlounge.mdx";
+import Aither from "/snippets/categories/aither.mdx";
 import AlphaRatio from "/snippets/categories/ar.mdx";
 import Animebytes from "/snippets/categories/animebytes.mdx";
 import AnimeWorld from "/snippets/categories/animeworld.mdx";
@@ -20,6 +21,8 @@ import MorethanTV from "/snippets/categories/mtv.mdx";
 import MyAnonamouse from "/snippets/categories/mam.mdx";
 import Nebulance from "/snippets/categories/nebulance.mdx";
 import Norbits from "/snippets/categories/norbits.mdx";
+import Piratethenet from "/snippets/categories/ptn.mdx";
+import PixelHD from "/snippets/categories/pixelhd.mdx";
 import Pretome from "/snippets/categories/pretome.mdx";
 import RED from "/snippets/categories/red.mdx";
 import RevolutionTT from "/snippets/categories/revolutiontt.mdx";
@@ -33,6 +36,7 @@ import TorrentSyndikat from "/snippets/categories/torrentsyndikat.mdx";
 import xSpeeds from "/snippets/categories/xspeeds.mdx";
 
 <AcidLounge />
+<Aither />
 <AlphaRatio />
 <Animebytes />
 <AnimeWorld />
@@ -54,6 +58,8 @@ import xSpeeds from "/snippets/categories/xspeeds.mdx";
 <MyAnonamouse />
 <Nebulance />
 <Norbits />
+<Piratethenet />
+<PixelHD />
 <Pretome />
 <RED />
 <RevolutionTT />

--- a/snippets/indexers.mdx
+++ b/snippets/indexers.mdx
@@ -2,23 +2,27 @@
   <summary>Click to view supported indexers</summary>
 
 - AcidLounge
+- Aither
 - AlphaRatio
 - AnimeBytes
 - BeyondHD
 - Bit-HDTV
-- BTFiles
+- BitSexy
 - BroadcasTheNet
+- BTFiles
+- Cathode-Ray Tube
 - DanishBytes
 - DigitalCore
+- DocsPedia.world
 - Empornium
 - Enthralled
 - FileList
 - Fuzer
 - GazelleGames
-- HDBits
-- Hebits
 - HD-Space
 - HD-Torrents
+- HDBits
+- Hebits
 - Huno
 - ImmortalSeed
 - IPTorrents
@@ -30,17 +34,20 @@
 - Norbits
 - OppaiTime
 - Orpheus
-- PornBay
+- PassThePopcorn
+- Piratethenet
+- PixelHD
 - PolishSource
 - PolishTracker
+- PornBay
 - PreToMe
-- PassThePopcorn
 - PussyTorrents
 - Redacted
 - RetroFlix
 - RevolutionTT
 - Romanian Metal Torrents
 - SceneHD
+- SkipTheCommericals
 - SpeedApp
 - SubsPlease
 - SuperBits


### PR DESCRIPTION
New supported indexers:

- Aither
- Piratethenet
- PixelHD
- BitSexy
- Cathode-Ray Tube
- DocsPedia.world
- SkipTheCommericals

Added categories from Aither, PTN and PixelHD.