### PR TITLE
docs: add download clients for Bytesized Hosting

### DIFF
--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -56,4 +56,14 @@ box start deluge-web
 
 </TabItem>
 
+<TabItem value="bytesized-deluge" label="Bytesized Hosting">
+
+- Host: `<username><hostname>.bysh.me`
+- Port: `DAEMON_PORT`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/lidarr.mdx
+++ b/snippets/shared-download-clients/lidarr.mdx
@@ -39,4 +39,12 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="bytesized-lidarr" label="Bytesized Hosting">
+
+- Host: `https://<username>.<hostname>.bysh.me/lidarr`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/radarr.mdx
+++ b/snippets/shared-download-clients/radarr.mdx
@@ -43,4 +43,12 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="bytesized-radarr" label="Bytesized Hosting">
+
+- Host: `https://<username>.<hostname>.bysh.me/radarr`
+- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -19,4 +19,12 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="bytesized-readarr" label="Bytesized Hosting">
+
+- Host: `https://<username>.<hostname>.bysh.me/readarr`
+- API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -27,4 +27,10 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="bytesized-rtorrent" label="Bytesized Hosting"> 
+
+- Host: `https://<username>:<password>@<username>.<hostname>.bysh.me/rutorrent/plugins/httprpc/action.php`
+
+</TabItem>
+
 </Tabs>

--- a/snippets/shared-download-clients/sonarr.mdx
+++ b/snippets/shared-download-clients/sonarr.mdx
@@ -43,4 +43,12 @@ import TabItem from "@theme/TabItem";
 
 </TabItem>
 
+<TabItem value="bytesized-radarr" label="Bytesized Hosting">
+
+- Host: `https://<username>.<hostname>.bysh.me/sonarr`
+- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</TabItem>
+
 </Tabs>


### PR DESCRIPTION
Ref https://github.com/autobrr/autobrr.com/issues/68

- Deluge
- Lidarr
- Radarr
- Readarr
- rTorrent
- Sonarr

qBittorrent was impossible to get working.
Transmission not supported.