### PR TITLE
docs(fix): removed twitter card line from config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,7 +45,6 @@ const config = {
     //   },
     // ],
     image: "img/autobrr.png",
-    metadata: [{ name: "twitter:card", content: "summary" }],
     docs: {
       sidebar: {
         //hideable: true,


### PR DESCRIPTION
twitter:card made link preview images very small.