### PR TITLE
docs: binding HBD deluge to 0.0.0.0 is not neccessary

### DIFF
--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -36,13 +36,6 @@ printf "10.0.0.1\n$(hostname -f)\n$(whoami)\n$(sed -rn 's/(.*)"daemon_port": (.*
 
 <details><summary>Hostingby.design</summary>
 
-```shell
-# Bind to 0.0.0.0 to enable remote connections
-box stop deluge-web
-sed -i 's/127.0.0.1/0.0.0.0/g' ~/.config/deluge/web.conf
-box start deluge-web
-```
-
 - Host: `<hostname>.itsby.design`
 - Port: `DAEMON_PORT`
 - TLS: Enabled


### PR DESCRIPTION
Removed this part as its not needed for autobrr to connect to it remotely. Tested and confirmed with torrents added successfully.

Just to clarify; it worked with binding to 0.0.0.0 as well, so this is not a fix per se.

https://github.com/autobrr/autobrr.com/blob/a00e941245ff5621b3932d2cbeeb6669e8449b06/snippets/shared-download-clients/deluge.mdx?plain=1#L39-L44