### PR TITLE
add documentation on which indexers support freeleech filtering

### DIFF
--- a/docs/filters/basics.md
+++ b/docs/filters/basics.md
@@ -169,9 +169,3 @@ Only supports `POST` requests for now.
 | **Except uploaders**      | Comma separated list of uploaders to ignore (takes priority over Match releases). | e.g. `anonymous,slow_uploader`                      | Depends on Indexer                                              |
 | **Freeleech**             | Should this filter match only Freeleech releases?                                     |                                                     | [Depends on Indexer](filters/freeleech)                         |
 | **Freeleech Percent**     | Allowed Freeleech Percentage for this filter to match.                                | e.g. `50%,75-100%`                                  | [Depends on Indexer, might not use percent.](filters/freeleech) |
-
-:::caution
-
-Don't combine Freeleech with Freeleech Percent! Freeleech is equal to setting Freeleech Percent to 100.
-
-:::

--- a/docs/filters/basics.md
+++ b/docs/filters/basics.md
@@ -155,20 +155,20 @@ Only supports `POST` requests for now.
 
 \* Full regex support (Golang flavour, check https://regex101.com)
 
-| Field                     | Description                                                                           | Examples                                            | Availability                               |
-| ------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------ |
-| \* **Match releases**     | Comma separated list of release names to match.                                       | e.g. `*Movie*remux*, That Other movie, *that?game*` | Always                                     |
-| \* **Except releases**    | Comma separated list of release names to ignore (takes priority over Match releases). | e.g. `Bad?Movie, *bad*`                             | Always                                     |
-| **Match release groups**  | Comma separated list of release groups to match.                                       | e.g. `GROUP1, OTHERGROUP`                           | Always                                     |
-| **Except release groups** | Comma separated list of release groups to ignore (takes priority over Match releases). | e.g. `BADGROUP1, OTHERBADGROUP`                     | Always                                     |
-| **Match categories**      | Comma separated list of categories to match.                                       | e.g. `tv,tv/1080p`                                  | Depends on Indexer                         |
-| **Except categories**     | Comma separated list of categories to ignore (takes priority over Match releases). | e.g. `tv/anime,tv/sports`                           | Depends on Indexer                         |
-| **Match tags**            | Comma separated list of tags to match.                                       | e.g. `action,romance`                               | Depends on Indexer                         |
-| **Except tags**           | Comma separated list of tags to ignore (takes priority over Match releases). | e.g. `foreign`                                      | Depends on Indexer                         |
-| **Match uploaders**       | Comma separated list of uploaders to match.                                       | e.g. `uploader1,otheruploader`                      | Depends on Indexer                         |
-| **Except uploaders**      | Comma separated list of uploaders to ignore (takes priority over Match releases). | e.g. `anonymous,slow_uploader`                      | Depends on Indexer                         |
-| **Freeleech**             | Should this filter match only Freeleech releases?                                     |                                                     | Depends on Indexer                         |
-| **Freeleech Percent**     | Allowed Freeleech Percentage for this filter to match.                                | e.g. `50%,75-100%`                                  | Depends on Indexer, might not use percent. |
+| Field                     | Description                                                                           | Examples                                            | Availability                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------- |-----------------------------------------------------------------|
+| \* **Match releases**     | Comma separated list of release names to match.                                       | e.g. `*Movie*remux*, That Other movie, *that?game*` | Always                                                          |
+| \* **Except releases**    | Comma separated list of release names to ignore (takes priority over Match releases). | e.g. `Bad?Movie, *bad*`                             | Always                                                          |
+| **Match release groups**  | Comma separated list of release groups to match.                                       | e.g. `GROUP1, OTHERGROUP`                           | Always                                                          |
+| **Except release groups** | Comma separated list of release groups to ignore (takes priority over Match releases). | e.g. `BADGROUP1, OTHERBADGROUP`                     | Always                                                          |
+| **Match categories**      | Comma separated list of categories to match.                                       | e.g. `tv,tv/1080p`                                  | Depends on Indexer                                              |
+| **Except categories**     | Comma separated list of categories to ignore (takes priority over Match releases). | e.g. `tv/anime,tv/sports`                           | Depends on Indexer                                              |
+| **Match tags**            | Comma separated list of tags to match.                                       | e.g. `action,romance`                               | Depends on Indexer                                              |
+| **Except tags**           | Comma separated list of tags to ignore (takes priority over Match releases). | e.g. `foreign`                                      | Depends on Indexer                                              |
+| **Match uploaders**       | Comma separated list of uploaders to match.                                       | e.g. `uploader1,otheruploader`                      | Depends on Indexer                                              |
+| **Except uploaders**      | Comma separated list of uploaders to ignore (takes priority over Match releases). | e.g. `anonymous,slow_uploader`                      | Depends on Indexer                                              |
+| **Freeleech**             | Should this filter match only Freeleech releases?                                     |                                                     | [Depends on Indexer](filters/freeleech)                         |
+| **Freeleech Percent**     | Allowed Freeleech Percentage for this filter to match.                                | e.g. `50%,75-100%`                                  | [Depends on Indexer, might not use percent.](filters/freeleech) |
 
 :::caution
 

--- a/docs/filters/examples.md
+++ b/docs/filters/examples.md
@@ -128,7 +128,7 @@ If you DON'T WANT ANY HDR formats
 
 If you are in need of buffer this is an example that will work will on general indexers with freeleech/bonus systems.
 
-Check your indexer for specifics.
+Check your indexer or our [list of indexers supporting freeleech](freeleech) filtering for specifics.
 
 | Field     |  Values       |
 | --------- | ------------- |

--- a/docs/filters/freeleech.md
+++ b/docs/filters/freeleech.md
@@ -1,0 +1,47 @@
+---
+title: Freeleech
+description: List of indexers supporting freeleech
+keywords: [autobrr, filters, freeleech]
+pagination_label: Filters - Freeleech
+---
+
+# Freeleech
+
+Not all indexers implemented in autobrr support the freeleech filtering.  
+This is due to the indexer simply not announcing freeleech.  
+
+To check if you can filter for freeleech, we have put together a list for you to see if you can filter for freeleech.
+Indexers under the Freeleech category only support the freeleech switch in autobrr.  
+Whereas indexers under the freeleech percent category support values in the freeleech percent field  
+and the freeleech switch - in case the release is 100% freeleech.
+
+:::caution
+
+Don't combine Freeleech with Freeleech Percent! Freeleech is equal to setting Freeleech Percent to 100.
+
+:::
+
+## Freeleech
+- AlphaRatio
+- AnimeBytes
+- DanishBytes
+- FileList
+- FunFile
+- GazelleGames
+- HUNO
+- iPlay
+- IPTorrents
+- MyAnonamouse
+- PTFiles
+- Pussytorrents
+- SuperBits
+- TorrentDay
+- TorrentLeech
+
+
+## Freeleech Percent
+- Aither
+- Locadora
+- LST
+- SkipTheCommericals
+- SkipTheTrailers

--- a/docs/filters/freeleech.md
+++ b/docs/filters/freeleech.md
@@ -15,12 +15,6 @@ Indexers under the Freeleech category only support the freeleech switch in autob
 Whereas indexers under the freeleech percent category support values in the freeleech percent field  
 and the freeleech switch - in case the release is 100% freeleech.
 
-:::caution
-
-Don't combine Freeleech with Freeleech Percent! Freeleech is equal to setting Freeleech Percent to 100.
-
-:::
-
 ## Freeleech
 - AlphaRatio
 - AnimeBytes

--- a/sidebars.js
+++ b/sidebars.js
@@ -50,6 +50,7 @@ module.exports = {
         "filters/omegabrr",
         "filters/examples",
         "filters/categories",
+        "filters/freeleech",
       ],
     },
     {


### PR DESCRIPTION
I'm not quite sure if creating a dedicated page for this, is the way to go.
If someone has a better idea feel free to suggest a more suitable way!