### PR TITLE
docs: Add RapidSeedbox's Lean client configs and sort hosts by alphabet

### DIFF
--- a/docs/configuration/download-clients/shared.md
+++ b/docs/configuration/download-clients/shared.md
@@ -62,7 +62,7 @@ Some ambiguous characters (such as @ : # % and more) may escape out of the URL.
 In this case you will have to change your password for ruTorrent to be able to add the client to autobrr.
 :::
 
-### Transmisison
+### Transmission
 
 import SharedTransmission from '/snippets/shared-download-clients/transmission.mdx';
 

--- a/snippets/shared-download-clients/deluge.mdx
+++ b/snippets/shared-download-clients/deluge.mdx
@@ -1,6 +1,6 @@
-<details><summary>Ultra.CC</summary>
+<details><summary>Bytesized Hosting</summary>
 
-- Host: `<hostname>.usbx.me`
+- Host: `<username><hostname>.bysh.me`
 - Port: `DAEMON_PORT`
 - TLS: Enabled
 - Username: `<username>`
@@ -8,18 +8,7 @@
 
 </details>
 
-<details><summary>Seedhost</summary>
-
-- Host: `<hostname>.seedhost.eu`
-- Port: `DAEMON_PORT`
-- TLS: `Enabled`
-- Username: `<username>`
-- Password: `<password>`
-
-</details>
-
 <details><summary>Feralhosting</summary>
-
 
 ```shell
 # Grab credentials via SSH
@@ -44,9 +33,9 @@ printf "10.0.0.1\n$(hostname -f)\n$(whoami)\n$(sed -rn 's/(.*)"daemon_port": (.*
 
 </details>
 
-<details><summary>Bytesized Hosting</summary>
+<details><summary>Seedhost</summary>
 
-- Host: `<username><hostname>.bysh.me`
+- Host: `<hostname>.seedhost.eu`
 - Port: `DAEMON_PORT`
 - TLS: Enabled
 - Username: `<username>`
@@ -58,8 +47,18 @@ printf "10.0.0.1\n$(hostname -f)\n$(whoami)\n$(sed -rn 's/(.*)"daemon_port": (.*
 
 - Host: localhost
 - Port: `DAEMON_PORT`
-- TLS: disabled
+- TLS: Disabled
 - Username: `seedit4me`
 - Password: `<your slot password>`
+
+</details>
+
+<details><summary>Ultra.cc</summary>
+
+- Host: `<hostname>.usbx.me`
+- Port: `DAEMON_PORT`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </details>

--- a/snippets/shared-download-clients/lidarr.mdx
+++ b/snippets/shared-download-clients/lidarr.mdx
@@ -1,14 +1,6 @@
-<details><summary>Ultra.cc</summary>
+<details><summary>Bytesized Hosting</summary>
 
-- Host: `https://<username>.<hostname>.usbx.me/lidarr`
-- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
-
-</details>
-
-<details><summary>Seedhost.eu</summary>
-
-- Host: `https://<hostname>.seedhost.eu/<username>/lidarr`
+- Host: `https://<username>.<hostname>.bysh.me/lidarr`
 - API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -34,9 +26,9 @@
 
 </details>
 
-<details><summary>Bytesized Hosting</summary>
+<details><summary>Seedhost.eu</summary>
 
-- Host: `https://<username>.<hostname>.bysh.me/lidarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/lidarr`
 - API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -45,6 +37,14 @@
 <details><summary>Seedit4.me</summary>
 
 - Host: `http://localhost:8686/lidarr/`
+- API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Disabled
+
+</details>
+
+<details><summary>Ultra.cc</summary>
+
+- Host: `https://<username>.<hostname>.usbx.me/lidarr`
 - API Key: `API Key` (Lidarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 

--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -1,23 +1,3 @@
-<details><summary>Ultra.cc</summary>
-
-- Host: `https://<username>.<hostname>.usbx.me/qbittorrent`
-- TLS: Enabled
-- Username: `<username>`
-- Password: `<password>`
-- Basic Auth: Disabled
-
-</details>
-
-<details><summary>Seedhost.eu</summary>
-
-- Host: `https://<hostname>.seedhost.eu/qbittorrent/`
-- TLS: Enabled
-- Username: `<username>`
-- Password: `<password>`
-- Basic Auth: Disabled
-
-</details>
-
 <details><summary>Feralhosting</summary>
 
 - Host `http://<username>.argus.feralhosting.com:<port>`
@@ -40,12 +20,43 @@
 
 </details>
 
+<details><summary>RapidSeedbox - Lean</summary>
+
+Grab your unique qBittorrent url from the from your `Services` page.
+
+- Host `https://<username>-qb.<hostname>.seedbox.vip/`
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</details>
+
+<details><summary>Seedhost.eu</summary>
+
+- Host: `https://<hostname>.seedhost.eu/qbittorrent/`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
+- Basic Auth: Disabled
+
+</details>
+
 <details><summary>Seedit4.me</summary>
 
 - Host `localhost:9148`
 - TLS: Disabled
 - Username: `seedit4me`
 - Password: `<your slot password>`
+- Basic Auth: Disabled
+
+</details>
+
+<details><summary>Ultra.cc</summary>
+
+- Host: `https://<username>.<hostname>.usbx.me/qbittorrent`
+- TLS: Enabled
+- Username: `<username>`
+- Password: `<password>`
 - Basic Auth: Disabled
 
 </details>

--- a/snippets/shared-download-clients/radarr.mdx
+++ b/snippets/shared-download-clients/radarr.mdx
@@ -1,20 +1,8 @@
-<details><summary>Ultra.cc</summary>
+<details><summary>Bytesized Hosting</summary>
 
-- Host: `https://<username>.<hostname>.usbx.me/radarr`
+- Host: `https://<username>.<hostname>.bysh.me/radarr`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Enabled
-- Username: `<username>`
-- Password: `<password>`
-
-</details>
-
-<details><summary>Seedhost.eu</summary>
-
-- Host: `https://<hostname>.seedhost.eu/<username>/radarr`
-- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Enabled
-- Username: `<username>`
-- Password: `<password>`
+- Basic Auth: Disabled
 
 </details>
 
@@ -38,11 +26,13 @@
 
 </details>
 
-<details><summary>Bytesized Hosting</summary>
+<details><summary>Seedhost.eu</summary>
 
-- Host: `https://<username>.<hostname>.bysh.me/radarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/radarr`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </details>
 
@@ -51,5 +41,15 @@
 - Host: `http://localhost:7878/radarr/`
 - API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
+
+</details>
+
+<details><summary>Ultra.cc</summary>
+
+- Host: `https://<username>.<hostname>.usbx.me/radarr`
+- API Key: `API Key` (Radarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </details>

--- a/snippets/shared-download-clients/readarr.mdx
+++ b/snippets/shared-download-clients/readarr.mdx
@@ -1,6 +1,6 @@
-<details><summary>Ultra.cc</summary>
+<details><summary>Bytesized Hosting</summary>
 
-- Host: `https://<username>.<hostname>.usbx.me/readarr`
+- Host: `https://<username>.<hostname>.bysh.me/readarr`
 - API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 
@@ -14,9 +14,9 @@
 
 </details>
 
-<details><summary>Bytesized Hosting</summary>
+<details><summary>Ultra.cc</summary>
 
-- Host: `https://<username>.<hostname>.bysh.me/readarr`
+- Host: `https://<username>.<hostname>.usbx.me/readarr`
 - API Key: `API Key` (Readarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
 

--- a/snippets/shared-download-clients/rtorrent.mdx
+++ b/snippets/shared-download-clients/rtorrent.mdx
@@ -1,12 +1,6 @@
-<details><summary>Ultra.cc</summary>
+<details><summary>Bytesized Hosting</summary>
 
-- Host: `https://<username>:<password>@<username>.<hostname>.usbx.me/RPC2`
-
-</details>
-
-<details><summary>Seedhost.eu</summary>
-
-- Host: `https://<username>:<password>@<hostname>.seedhost.eu/<username>/rutorrent/plugins/httprpc/action.php`
+- Host: `https://<username>:<password>@<username>.<hostname>.bysh.me/rutorrent/plugins/httprpc/action.php`
 
 </details>
 
@@ -22,9 +16,21 @@
 
 </details>
 
-<details><summary>Bytesized Hosting</summary>
+<details><summary>RapidSeedbox - Lean</summary>
 
-- Host: `https://<username>:<password>@<username>.<hostname>.bysh.me/rutorrent/plugins/httprpc/action.php`
+Grab your unique ruTorrent url from the from your `Services` page.
+
+- Host `https://<username>-rt.<hostname>.seedbox.vip/RPC2`
+- TLS: Enabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
+
+</details>
+
+<details><summary>Seedhost.eu</summary>
+
+- Host: `https://<username>:<password>@<hostname>.seedhost.eu/<username>/rutorrent/plugins/httprpc/action.php`
 
 </details>
 
@@ -34,18 +40,21 @@
 
 </details>
 
+<details><summary>Ultra.cc</summary>
+
+- Host: `https://<username>:<password>@<username>.<hostname>.usbx.me/RPC2`
+
+</details>
+
 <details><summary>WhatBox</summary>
 
 - Host: `https://<hostname>.whatbox.ca/xmlrpc`
-
-- TLS: On
-
+- TLS: Enabled
 - Skip TLS verification (insecure): Off
-
 - Basic auth: On
-
 - Username: `<username>`
-
 - Password `<password>`
 
 </details>
+
+

--- a/snippets/shared-download-clients/sonarr.mdx
+++ b/snippets/shared-download-clients/sonarr.mdx
@@ -1,20 +1,8 @@
-<details><summary>Ultra.cc</summary>
+<details><summary>Bytesized Hosting</summary>
 
-- Host: `https://<username>.<hostname>.usbx.me/sonarr`
+- Host: `https://<username>.<hostname>.bysh.me/sonarr`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Enabled
-- Username: `<username>`
-- Password: `<password>`
-
-</details>
-
-<details><summary>Seedhost.eu</summary>
-
-- Host: `https://<hostname>.seedhost.eu/<username>/sonarr`
-- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Enabled
-- Username: `<username>`
-- Password: `<password>`
+- Basic Auth: Disabled
 
 </details>
 
@@ -38,11 +26,13 @@
 
 </details>
 
-<details><summary>Bytesized Hosting</summary>
+<details><summary>Seedhost.eu</summary>
 
-- Host: `https://<username>.<hostname>.bysh.me/sonarr`
+- Host: `https://<hostname>.seedhost.eu/<username>/sonarr`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
-- Basic Auth: Disabled
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </details>
 
@@ -51,5 +41,15 @@
 - Host: `http://localhost:8989/sonarr/`
 - API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
 - Basic Auth: Disabled
+
+</details>
+
+<details><summary>Ultra.cc</summary>
+
+- Host: `https://<username>.<hostname>.usbx.me/sonarr`
+- API Key: `API Key` (Sonarr's API Key found in Settings -> General -> Security) 
+- Basic Auth: Enabled
+- Username: `<username>`
+- Password: `<password>`
 
 </details>

--- a/snippets/shared-download-clients/transmission.mdx
+++ b/snippets/shared-download-clients/transmission.mdx
@@ -1,8 +1,20 @@
-<details><summary>Ultra.cc</summary>
+<details><summary>Feralhosting</summary>
 
-- Host: `<username>.<hostname>.usbx.me`
-- Port: Transmissions' RPC Port as given in your Control Panel
+- Host: `<hostname>.feralhosting.com/<username>/transmission/rpc`
+- Port: 9091
 - TLS: Enabled
+- Password: `<password>`
+
+</details>
+
+<details><summary>RapidSeedbox - Lean</summary>
+
+Grab your unique Transmission url from the from your `Services` page.
+
+- Host `<username>-tr.<hostname>.seedbox.vip/rpc`
+- Port `443`
+- TLS: Enabled
+- Basic Auth: Enabled
 - Username: `<username>`
 - Password: `<password>`
 
@@ -23,11 +35,12 @@ echo -e "Your Transmission port: \e[31m$(grep '"rpc-port": [0-9]*' ~/.config/tra
 
 </details>
 
-<details><summary>Feralhosting</summary>
+<details><summary>Ultra.cc</summary>
 
-- Host: `<hostname>.feralhosting.com/<username>/transmission/rpc`
-- Port: 9091
+- Host: `<username>.<hostname>.usbx.me`
+- Port: Transmissions' RPC Port as given in your Control Panel
 - TLS: Enabled
+- Username: `<username>`
 - Password: `<password>`
 
 </details>


### PR DESCRIPTION
Changes:

- Add RapidSeedbox qBit, rTorrent, Transmission clients under Shared seedbox providers section
- Sort the shared seedbox providers alphabetically