### PR TITLE
Updates shared seedhost documentation for qbittorrent

### DIFF
--- a/snippets/shared-download-clients/qbittorrent.mdx
+++ b/snippets/shared-download-clients/qbittorrent.mdx
@@ -33,7 +33,7 @@ Grab your unique qBittorrent url from the from your `Services` page.
 
 <details><summary>Seedhost.eu</summary>
 
-- Host: `https://<hostname>.seedhost.eu/qbittorrent/`
+- Host: `https://<hostname>.seedhost.eu/<username>/qbittorrent/`
 - TLS: Enabled
 - Username: `<username>`
 - Password: `<password>`


### PR DESCRIPTION
The URL generated for a particular user must be used in order for this to work (tested in v1.31)