### PR TITLE
chore(docs): update cross-seed tutorial

### DIFF
--- a/docs/3rd-party-tools.md
+++ b/docs/3rd-party-tools.md
@@ -134,15 +134,13 @@ The way this works is you create a filter with a higher priority set than any ot
 2. Create a filter and name it eg. `cross-seed`.
 3. Select all the indexers you want to use, preferably all of them.
 4. Set a really high `priority` to make sure it's always higher than your other filters.
-5. Go to the `External` tab, enable the `Webhook` switch, and add the following below it:
+5. Go to the `External` tab, and add a new External filter.
 
-
+   - Type: `Webhook`
    - Host: `http://localhost:2468/api/announce`
    - Headers: `x-api-key=YOUR_API_KEY`
-   - Select HTTP Method: `POST`
+   - HTTP Method: `POST`
    - Expected http status: `200`  
-
-
    - Data (JSON):
 
    ```json

--- a/docs/3rd-party-tools.md
+++ b/docs/3rd-party-tools.md
@@ -137,7 +137,9 @@ The way this works is you create a filter with a higher priority set than any ot
 5. Go to the `External` tab, enable the `Webhook` switch, and add the following below it:
 
 
-   - Host: `http://localhost:2468/api/announce?apikey=YOUR_API_KEY`  
+   - Host: `http://localhost:2468/api/announce`
+   - Headers: `x-api-key=YOUR_API_KEY`
+   - Select HTTP Method: `POST`
    - Expected http status: `200`  
 
 

--- a/docs/3rd-party-tools.md
+++ b/docs/3rd-party-tools.md
@@ -68,7 +68,6 @@ Even with API auth enabled, cross-seed still recommends that you do not expose i
 You can use iptables or UFW to solve this.  
 The cross-seed daemon uses port 2468 by default.
 If you want to expose cross-seed to another server on the internet substitute `127.0.0.1` with the IP of the corresponding server.
-<br />  
 
 ```text
 sudo apt-get install iptables
@@ -124,11 +123,12 @@ sudo journalctl -u cross-seed # view the logs
 The way this works is you create a filter with a higher priority set than any other filter to make sure every cross-seed match is forwarded to the cross-seed daemon instead of being run through other filters.
 
 1. Get your API key with the following command:  
-```
-cross-seed api-key
-```
-&nbsp&nbsp&nbsp&nbsp&nbsp Keep this key at hand since we will need it at step 5 later on.  
-&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp In the rest of this tutorial, we will refer to this as `YOUR_API_KEY`.
+  
+    ```
+    cross-seed api-key
+    ```
+    Keep this key at hand since we will need it at step 5 later on.  
+    In the rest of this tutorial, we will refer to this as `YOUR_API_KEY`.
 
 
 2. Create a filter and name it eg. `cross-seed`.

--- a/docs/3rd-party-tools.md
+++ b/docs/3rd-party-tools.md
@@ -20,9 +20,9 @@ With this setup you can utilize autobrr with [cross-seed](https://github.com/cro
 
 ### Install cross-seed and its dependencies {#cross-seed-install}
 
-You can install cross-seed in several ways. Docker is recommended, but installing via npm or yarn (requires node 14 or greater) is also fine.
+You can install cross-seed in several ways. Docker is recommended, but installing via npm or yarn (requires node 16 or greater) is also fine.
 
-In this guide we will install it with npm. This method requires node 14 or greater.
+In this guide we will install it with npm. This method requires node 16 or greater.
 <https://github.com/nodesource/distributions/blob/master/README.md#using-debian-as-root-3>
 
 ```bash
@@ -59,11 +59,16 @@ torrentDir: "/home/$USER/.local/share/qBittorrent/BT_backup",
 outputDir: "/home/$USER/torrentfiles",
 action: "inject",
 qbittorrentUrl: "http://user:pass@localhost:port",
+apiAuth: true,
 ```
 
-:::danger Make sure the port is not exposed to the internet
+:::info Make sure the port is not exposed to the internet
 
-Since cross-seed doesn't have API auth, we need to make sure its port isn't open to the internet. You can use iptables or UFW to solve this. Cross-seed daemon uses port 2468 by default.
+Even with API auth enabled, cross-seed still recommends that you do not expose its port to untrusted networks (such as the Internet).
+You can use iptables or UFW to solve this.  
+The cross-seed daemon uses port 2468 by default.
+If you want to expose cross-seed to another server on the internet substitute `127.0.0.1` with the IP of the corresponding server.
+<br />  
 
 ```text
 sudo apt-get install iptables
@@ -118,14 +123,25 @@ sudo journalctl -u cross-seed # view the logs
 
 The way this works is you create a filter with a higher priority set than any other filter to make sure every cross-seed match is forwarded to the cross-seed daemon instead of being run through other filters.
 
-1. Create a filter and name it eg. `cross-seed`.
-2. Select all the indexers you want to use, preferably all of them.
-3. Set a really high `priority` to make sure it's always higher than your other filters.
-4. Go to the `External` tab, enable the `Webhook` switch, and add the following below it:
+1. Get your API key with the following command:  
+```
+cross-seed api-key
+```
+&nbsp&nbsp&nbsp&nbsp&nbsp Keep this key at hand since we will need it at step 5 later on.  
+&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp In the rest of this tutorial, we will refer to this as `YOUR_API_KEY`.
 
-   Host: `http://localhost:2468/api/announce`  
-   Expected http status: `200`  
-   Data (JSON):
+
+2. Create a filter and name it eg. `cross-seed`.
+3. Select all the indexers you want to use, preferably all of them.
+4. Set a really high `priority` to make sure it's always higher than your other filters.
+5. Go to the `External` tab, enable the `Webhook` switch, and add the following below it:
+
+
+   - Host: `http://localhost:2468/api/announce?apikey=YOUR_API_KEY`  
+   - Expected http status: `200`  
+
+
+   - Data (JSON):
 
    ```json
    {
@@ -136,8 +152,9 @@ The way this works is you create a filter with a higher priority set than any ot
    }
    ```
 
-5. Go to the `Actions` tab and create a Test action. This is required for the webhook to work.
-6. Finally, make sure the filter is enabled and you're all set.
+
+6. Go to the `Actions` tab and create a Test action. This is required for the webhook to work.
+7. Finally, make sure the filter is enabled and you're all set.
 
 :::tip Cross-seed notifications
 You can set up a Notifiarr or Apprise webhook for cross-seed notifications within the cross-seed config.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -200,6 +200,10 @@ li[class*="theme-doc-sidebar-item-category-level"] a.menu__link:hover:not(.menu_
   font-size: 0.9rem;
 }
 
+pre {
+  background-color: var(--slate-3);
+}
+
 pre > code {
   border: 1px solid var(--slate-9);
 }
@@ -210,6 +214,7 @@ div.theme-code-block pre > code {
 
 div.theme-code-block {
   border: 1px solid var(--slate-9);
+  margin-top: 22px;
 }
 
 /* select only divs which have len(elems) == 2 */

--- a/src/theme/Details/styles.module.css
+++ b/src/theme/Details/styles.module.css
@@ -4,7 +4,3 @@
   border: 1px solid var(--slate-6);
   background-color: var(--slate-3);
 }
-
-pre {
-  background-color: var(--slate-3);
-}


### PR DESCRIPTION
This PR updates the cross-seed setup tutorial on the docs.
Please thoroughly review the iptables section and the filter creation part
and feel free to make any changes.
I don't have any strong feeling about the changes I did.

EDIT:
The tutorial uses the apikey query param instead of the X-Api-Key HTTP header..
If there is a reason why it's better to use the header feel free to elaborate!
