### PR TITLE
docs: add ANT to the list of indexers supporting freeleech

### DIFF
--- a/docs/filters/freeleech.md
+++ b/docs/filters/freeleech.md
@@ -18,6 +18,7 @@ Whereas indexers under the freeleech percent category support values in the free
 
 - AlphaRatio
 - AnimeBytes
+- Anthelion
 - DanishBytes
 - FileList
 - FunFile


### PR DESCRIPTION
Update the documentation according to https://github.com/autobrr/autobrr/pull/1302.