### PR TITLE
docs(installers): update Saltbox instructions

### DIFF
--- a/snippets/seedbox-solution-installers.mdx
+++ b/snippets/seedbox-solution-installers.mdx
@@ -16,10 +16,10 @@ Swizzin documentation: [https://swizzin.ltd/applications/autobrr](https://swizzi
 <TabItem value="saltbox" label="Saltbox">
 
 ```shell
-sb install sandbox-autobrr
+sb install autobrr
 ```
 
-Saltbox documentation: [https://docs.saltbox.dev/sandbox/apps/autobrr/](https://docs.saltbox.dev/sandbox/apps/autobrr/)
+Saltbox documentation: [https://docs.saltbox.dev/apps/autobrr/](https://docs.saltbox.dev/apps/autobrr/)
 
 </TabItem>
 


### PR DESCRIPTION
Autobrr is a saltbox app now instead of sandbox app so docs updated accordingly https://github.com/autobrr/autobrr/pull/1410