### PR TITLE
fix(docs): update omegabrr download URL

### DIFF
--- a/docs/filters/omegabrr.md
+++ b/docs/filters/omegabrr.md
@@ -33,7 +33,7 @@ import { AiFillGithub } from 'react-icons/ai';
 Download the [latest release <AiFillGithub />](https://github.com/autobrr/omegabrr/releases/latest), or download the [source code <AiFillGithub />](https://github.com/autobrr/omegabrr) and build it yourself using `make build`.
 
 ```shell
-wget $(curl -s https://api.github.com/repos/autobrr/omegabrr/releases/latest | grep download | grep linux_x86_64 | cut -d\" -f4)
+wget $(curl -s https://api.github.com/repos/autobrr/omegabrr/releases/latest | grep download | grep linux_amd64 | cut -d\" -f4)
 ```
 
 ### Extract


### PR DESCRIPTION
Some build changes for omegabrr changed the architecture name for the artifacts.
This PR fixes the download URL in the docs to match the new architecture name.