### PR TITLE
docs: update cross-seed payload to use IndexerName

### DIFF
--- a/docs/3rd-party-tools.md
+++ b/docs/3rd-party-tools.md
@@ -148,7 +148,7 @@ The way this works is you create a filter with a higher priority set than any ot
      "name": "{{ .TorrentName }}",
      "guid": "{{ .TorrentUrl }}",
      "link": "{{ .TorrentUrl }}",
-     "tracker": "{{ .Indexer | js}}"
+     "tracker": "{{ .IndexerName | js}}"
    }
    ```
 


### PR DESCRIPTION
Update payload to use the new macro `IndexerName` for improved compatibility.