### PR TITLE
docs: remove duplicate headers

### DIFF
--- a/docs/3rd-party-tools/cross-seed.md
+++ b/docs/3rd-party-tools/cross-seed.md
@@ -1,12 +1,10 @@
 ---
 id: cross-seed
 sidebar_label: Cross-seed
-title: 3rd party tools
+title: Cross-seed with autobrr
 description: 3rd party tools that can be used with autobrr.
 keywords: [cross-seed]
 ---
-
-## Cross-seed with autobrr {#cross-seed}
 
 :::info Heads up
 

--- a/docs/3rd-party-tools/redacted-hook.md
+++ b/docs/3rd-party-tools/redacted-hook.md
@@ -6,8 +6,6 @@ description: 3rd party tool for Redacted.
 keywords: [helper,scripts,redactedhook,music]
 ---
 
-## Redactedhook
-
 RedactedHook is a webhook companion service for autobrr, designed to check the names of uploaders, your ratio and record labels associated with torrents on Redacted and Orpheus.
 
 ### Instructions {#redactedhook-instructions}

--- a/docs/3rd-party-tools/upgraderr.md
+++ b/docs/3rd-party-tools/upgraderr.md
@@ -6,7 +6,7 @@ description: arr, deduplication andd cross-seed functionality.
 keywords: [cross-seed,duplicates,deduplication,arr]
 ---
 
-## Upgraderr - Arr, deduplication, and cross-seed functionality {#upgraderr}
+## Arr, deduplication, and cross-seed functionality {#upgraderr}
 
 :::info Heads up
 This is meant for any kind of user. There is no configuration, and it's nearly impossible to make a mistake so long as the guide is followed with the modest amount of care.


### PR DESCRIPTION
The markdown document is using the title from the front matter section as header, so no need for another.