### PR TITLE
feat(docs): convert indexers list to detailed table format

### DIFF
--- a/scripts/generate_indexers_snippet.py
+++ b/scripts/generate_indexers_snippet.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+DEFINITIONS_DIR = "/Users/soup/github/autobrr/autobrr/internal/indexer/definitions"
+OUTPUT_FILE = "/Users/soup/github/autobrr/autobrr.com/snippets/indexers.mdx"
+
+import os
+import re
+from typing import Dict
+
+def parse_yaml_file(file_path: str) -> Dict:
+    """Parse YAML file manually for the fields we need."""
+    result = {}
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+        
+        # Extract fields using regex
+        name_match = re.search(r'name:\s*(.*)', content)
+        desc_match = re.search(r'description:\s*(.*)', content)
+        
+        supports_match = re.search(r'supports:\s*\n((?:\s*-\s*[^\n]+\n)*)', content)
+        supports = []
+        if supports_match:
+            supports = re.findall(r'-\s*(\w+)', supports_match.group(1))
+        
+        result = {
+            'name': name_match.group(1).strip() if name_match else '',
+            'description': desc_match.group(1).strip() if desc_match else '',
+            'supports': supports
+        }
+    return result
+
+def get_features(indexer: Dict) -> str:
+    """Extract supported features from indexer definition."""
+    return ', '.join(feat.upper() for feat in indexer.get('supports', []))
+
+def generate_markdown(definitions_dir: str, output_file: str):
+    """Generate markdown document for all indexers."""
+    indexers = []
+    
+    # Read the YAML files
+    for filename in os.listdir(definitions_dir):
+        if filename.endswith('.yaml'):
+            file_path = os.path.join(definitions_dir, filename)
+            indexer = parse_yaml_file(file_path)
+            if indexer:
+                indexers.append(indexer)
+    
+    # Sort indexers by name, but put generic ones last
+    def sort_key(indexer):
+        name = indexer.get('name', '').lower()
+
+        return (name.startswith('generic'), name)
+    
+    indexers.sort(key=sort_key)
+    
+    # Generate markdown content
+    markdown = "<details>\n\n"
+    markdown += "<summary>Click to view supported indexers</summary>\n\n"
+    markdown += "| Indexer | Description | Features |\n"
+    markdown += "|---------|-------------|----------|\n"
+    
+    last_was_generic = False
+    for indexer in indexers:
+        name = indexer.get('name', '').lower()
+        
+        if name.startswith('generic') and not last_was_generic:
+            last_was_generic = True
+            
+        name = indexer.get('name', '')
+        description = indexer.get('description', '')
+        features = get_features(indexer)
+        
+        markdown += f"| {name} | {description} | {features} |\n"
+    
+    markdown += "\n</details>"
+
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(markdown)
+
+if __name__ == "__main__":
+    generate_markdown(DEFINITIONS_DIR, OUTPUT_FILE)

--- a/snippets/indexers.mdx
+++ b/snippets/indexers.mdx
@@ -1,94 +1,99 @@
 <details>
-  <summary>Click to view supported indexers</summary>
 
-- ABNormal
-- Acid-Lounge
-- Aither
-- AlphaRatio
-- AnimeBytes
-- AnimeWorld
-- Anthelion
-- Bemaniso
-- BeyondHD
-- BIT-HDTV
-- BitHUmen
-- BitSexy
-- BitTorrentFiles
-- BroadcasTheNet
-- BrokenStones
-- Cathode-Ray Tube
-- DanishBytes
-- DigitalCore
-- DocsPedia
-- Empornium
-- Enthralled
-- FearNoPeer
-- FileList
-- FinElite
-- FunFile
-- Fuzer
-- GazelleGames
-- Hawke-UNO
-- HD-Only
-- HD-Space
-- HD-Torrents
-- HDBits
-- Hebits
-- iAnon
-- ImmortalSeed
-- iNSANE
-- IPTorrents
-- KeepFRDS
-- LilleSky
-- Locadora
-- LST
-- LustHive
-- Milkie
-- MoreThanTv
-- MyAnonamouse
-- nCore
-- Nebulance
-- Norbits
-- Nyaa
-- OnlyEncodes
-- Orpheus
-- PassThePopcorn
-- PixelHD
-- PolishSource
-- PolishTracker
-- Pornbay
-- PreToMe
-- PTFiles
-- PussyTorrents
-- Redacted
-- ReelFliX
-- RetroFlix
-- RevolutionTT
-- Romanian Metal Torrents
-- SATClubbing
-- SceneHD
-- SeedPool
-- Sharewood
-- SpeedApp
-- SubsPlease
-- SugoiMusic
-- SuperBits
-- TheDarkCommunity
-- TheOldSchool
-- Tokyo Toshokan
-- TorrentBytes
-- TorrentDay
-- TorrentHR
-- TorrentLeech
-- TorrentNetwork
-- TorrentSectorCrew
-- TorrentSeeds
-- TorrentSeeds Music
-- TorrentSyndikat
-- TranceTraffic
-- UHDBits
-- XSpeeds
+<summary>Click to view supported indexers</summary>
 
-along with the **Generic RSS** and **Generic Torznab/Newznab** integration.
+| Indexer                 | Description                                                                                                  | Features      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| ABNormal                | ABNormal (ABN) is a French General tracker                                                                   | IRC, RSS      |
+| Acid-Lounge             | Small general tracker.                                                                                       | IRC, RSS      |
+| Aither                  | Aither is a community-built Movie/TV/FANRES database.                                                        | IRC, RSS      |
+| AlphaRatio              | AlphaRatio (AR) is a private torrent tracker for 0DAY / GENERAL                                              | IRC, RSS      |
+| AnimeBytes              | AnimeBytes (AB) is a private torrent tracker for Anime, Manga, J-Music, OSTS, Hentai, Games and Light Novel. | IRC, RSS      |
+| AnimeWorld              | AnimeWorld is a private indexer for Anime.                                                                   | IRC, RSS      |
+| Anthelion               | Anthelion (ANT) is a Private Torrent Tracker for MOVIES                                                      | IRC, RSS      |
+| Bemaniso                | Bemaniso is a private tracker for Bemani which is a series of music and rhythm games by Konami               | IRC           |
+| BeyondHD                | BeyondHD (BHD) is a private torrent tracker for HD MOVIES / TV                                               | IRC, RSS      |
+| BIT-HDTV                | Bit-HDTV (BHDTV) is a specialized HD tracker in movies and TV with so many daily uploads.                    | IRC, RSS      |
+| BitHUmen                | BitHUmen is a Hungarian Private site for TV / MOVIES / GENERAL                                               | IRC, RSS      |
+| BitSexy                 | BitSexy (BSEX) is a private torrent tracker for XXX                                                          | IRC, RSS      |
+| BitTorrentFiles         | BitTorrentFiles (BTF) is a GERMAN private torrent tracker for MOVIES / TV / GENERAL.                         | IRC, RSS      |
+| BroadcasTheNet          | BroadcasTheNet (BTN) is a private torrent tracker focused on TV shows                                        | IRC, RSS, API |
+| BrokenStones            | BrokenStones is a Private Torrent Tracker for macOS                                                          | IRC, RSS      |
+| Cathode-Ray Tube        | Cathode-Ray Tube (CRT) is a private torrent tracker for classic and international movies.                    | IRC, RSS      |
+| DanishBytes             | DanishBytes is a private torrent tracker for HD MOVIES / TV                                                  | IRC, RSS      |
+| DigitalCore             | DigitalCore (DC) is a private torrent tracker for General / 0 Day.                                           | IRC, RSS      |
+| DocsPedia               | DocsPedia.world private torrent tracker for EDUCATION                                                        | IRC, RSS      |
+| Empornium               | Empornium (EMP) is a private torrent tracker for XXX                                                         | IRC, RSS      |
+| Enthralled              | Enthralled (ENT) is a private torrent tracker for XXX                                                        | IRC, RSS      |
+| FearNoPeer              | FearNoPeer (FnP) is a private torrent tracker for Movies, TV Shows & General releases                        | IRC, RSS      |
+| FileList                | FileList (FL) is a ROMANIAN private torrent tracker for MOVIES / TV / GENERAL                                | IRC, RSS      |
+| FinElite                | FinElite (FE) is a finnish private tracker.                                                                  | IRC           |
+| FunFile                 | Welcome to funfile.org, where files are fun!                                                                 | IRC, RSS      |
+| Fuzer                   | Fuzer is a private Israeli tracker                                                                           | IRC           |
+| GazelleGames            | GazelleGames (GGn) is a private torrent tracker for GAMES                                                    | IRC, RSS, API |
+| Hawke-UNO               | Hawke-UNO (HUNO) is a private torrent tracker for MOVIES / TV.                                               | IRC, RSS      |
+| HD-Only                 | HD-Only (HD-O) is a FRENCH Private Torrent Tracker for HD MOVIES / TV                                        | IRC, RSS      |
+| HD-Space                | HD-Space (HDS) is a Private Torrent Tracker for HD MOVIES / TV                                               | IRC, RSS      |
+| HD-Torrents             | HD-Torrents (HD-T) is a private torrent tracker for HD MOVIES / TV                                           | IRC, RSS      |
+| HDBits                  | Private HD tracker                                                                                           | IRC, RSS      |
+| Hebits                  | Hebits is a private Israeli tracker                                                                          | IRC           |
+| iAnon                   | iAnon is a Private Torrent Tracker for macOS                                                                 | IRC, RSS      |
+| ImmortalSeed            | ImmortalSeed (iS) is a Private Torrent Tracker for MOVIES / TV / GENERAL                                     | IRC, RSS      |
+| iNSANE                  | iNSANE is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL                                             | IRC, RSS      |
+| IPTorrents              | IPTorrents (IPT) is a private torrent tracker for 0DAY / GENERAL.                                            | IRC, RSS      |
+| KeepFRDS                | PT@KEEPFRDS is a CHINESE Private Torrent Tracker for HD MOVIES / TV                                          | IRC, RSS      |
+| Locadora                | Locadora is a Brazilian tracker for Movies, TV Shows and Animes.                                             | IRC           |
+| LST                     | LST is an English private tracker for MOVIES / TV / GENERAL                                                  | IRC, RSS      |
+| LustHive                | LustHive (Lsh) is a private torrent tracker for XXX                                                          | IRC, RSS      |
+| Milkie                  | Milkie is a private torrent tracker for GENERAL.                                                             | IRC, RSS      |
+| MoreThanTv              | MoreThanTv (MTV) is a torrent tracker for Series and Movies.                                                 | IRC, RSS      |
+| MyAnonamouse            | MyAnonaMouse (MAM) is a large ebook and audiobook tracker.                                                   | IRC, RSS      |
+| nCore                   | nCore                                                                                                        | IRC, RSS      |
+| Nebulance               | Nebulance (NBL) is a ratioless private torrent tracker for TV                                                | IRC, RSS      |
+| Norbits                 | NorBits is a Norwegian Private site for MOVIES / TV / GENERAL                                                | IRC, RSS      |
+| Nyaa                    | Nyaa is an indexer for Anime.                                                                                | IRC           |
+| OnlyEncodes             | OnlyEncodes (OE) is a private torrent tracker for MOVIES / TV                                                | IRC, RSS      |
+| Orpheus                 | Orpheus (OPS) is a Private Torrent Tracker for MUSIC                                                         | API, IRC, RSS |
+| PassThePopcorn          | PassThePopcorn (PTP) is a private torrent tracker for MOVIES                                                 | IRC, RSS      |
+| PixelHD                 | PixelHD is a specialty movie site. Ratio free.                                                               | IRC, RSS      |
+| PolishSource            | PolishSource (PS) is a POLISH private torrent tracker for 0DAY / GENERAL.                                    | IRC, RSS      |
+| PolishTracker           | PolishTracker (PT) is a POLISH private torrent tracker for 0DAY / GENERAL.                                   | IRC, RSS      |
+| Pornbay                 | Pornbay (PB) is a private torrent tracker for XXX                                                            | IRC, RSS      |
+| PreToMe                 | PreToMe (PTM) is 0Day/General ratioless tracker with very good speed & Pretime.                              | IRC, RSS      |
+| PrivateSilverScreen     | PrivateSilverScreen (PSS) is a private tracker for MOVIES / TV / MUSIC                                       | IRC, RSS      |
+| PTFiles                 | PTFiles (PTF) is a Private site for TV / MOVIES / GENERAL                                                    | IRC, RSS      |
+| PussyTorrents           | PussyTorrents is the adult sister site of the well known TorrentLeech.                                       | IRC, RSS      |
+| Redacted                | Redacted (RED) is a private torrent tracker for MUSIC                                                        | API, IRC, RSS |
+| ReelFliX                | ReelFliX (RFX) is an English private tracker for MOVIES                                                      | IRC, RSS      |
+| RetroFlix               | RetroFlix (RFX) is a private torrent tracker for CLASSIC MOVIES / TV / GENERAL                               | IRC, RSS      |
+| RevolutionTT            | RevolutionTT (RTT) is a private torrent tracker for 0DAY / GENERAL.                                          | IRC, RSS      |
+| Romanian Metal Torrents | Romanian Metal Torrents (RMT) is a private torrent tracker for METAL MUSIC.                                  | IRC, RSS      |
+| SATClubbing             | SATClubbing is a RUSSIAN/ENGLISH Private Torrent Tracker for ELECTRONIC MUSIC                                | IRC           |
+| SceneHD                 | SceneHD (SCHD) is a private torrent tracker for HD MOVIES / TV.                                              | IRC, RSS      |
+| SeedPool                | SeedPool is a private torrent tracker for 0DAY / GENERAL                                                     | IRC, RSS      |
+| Sharewood               | Sharewood (Sw) is a Private French Torrent Tracker for MOVIES / TV / GENERAL                                 | IRC, RSS      |
+| SpeedApp                | SpeedApp is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL                                     | IRC           |
+| SubsPlease              | SubsPlease is an indexer for Anime.                                                                          | IRC, RSS      |
+| SugoiMusic              | SugoiMusic (SM) is a private torrent tracker for MUSIC                                                       | IRC           |
+| SuperBits               | Superbits is a SWEDISH private torrent tracker for MOVIES / TV / 0DAY / GENERAL                              | IRC, RSS      |
+| TheDarkCommunity        | TheDarkCommunity (TDC) is a private torrent tracker for MOVIES / TV                                          | IRC, RSS      |
+| TheOldSchool            | TheOldSchool (TOS) is a general french tracker.                                                              | IRC, RSS      |
+| Tokyo Toshokan          | A BitTorrent Library for Japanese Media                                                                      | IRC           |
+| TorrentBytes            | TorrentsBytes (TBy) is a private torrent tracker for GENERAL                                                 | IRC, RSS      |
+| TorrentDay              | TorrentDay (TD) is a private torrent tracker for GENERAL.                                                    | IRC, RSS      |
+| TorrentHR               | TorrentHR (THR) is private croatian tracker                                                                  | IRC, RSS      |
+| TorrentLeech            | TorrentLeech (TL) is a private torrent tracker for 0DAY / GENERAL.                                           | IRC, RSS      |
+| TorrentNetwork          | Torrent Network (TN) is a GERMAN Private site for TV / MOVIES / GENERAL                                      | IRC, RSS      |
+| TorrentSectorCrew       | Torrent Sector Crew (TSC) is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL.                     | IRC, RSS      |
+| TorrentSeeds            | TorrentSeeds (TS) is a GENERAL/0-DAY tracker with great pretimes.                                            | IRC, RSS      |
+| TorrentSeeds Music      | TorrentSeeds (TS) is a GENERAL/0-DAY tracker with great pretimes.                                            | IRC, RSS      |
+| TorrentSyndikat         | TorrentSyndikat (TS) is a private german torrent tracker.                                                    | IRC, RSS      |
+| TranceTraffic           | TranceTraffic is a Private site for MUSIC                                                                    | IRC, RSS      |
+| UHDBits                 | UHDBits (UHD) is a private torrent tracker for HD MOVIES / TV                                                | IRC, RSS      |
+| Upload.cx               | ULCX is an English private tracker focused on quality movies and tv.                                         | IRC, RSS      |
+| XSpeeds                 | XSpeeds (XS) is a private torrent tracker for MOVIES / TV / GENERAL.                                         | IRC, RSS      |
+| Generic Newznab         | Newznab is an API search specification for Usenet                                                            | NEWZNAB       |
+| Generic RSS             | Generic RSS                                                                                                  | RSS           |
+| Generic Torznab         | Generic Torznab                                                                                              | TORZNAB       |
 
 </details>


### PR DESCRIPTION
This PR enhances the list of supported indexers by converting the simple bullet-point list into a comprehensive table format.

This was made using a python script that reads from the definitions directory.

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/520c0c00-a318-4012-bfcd-111338427581">
