### PR TITLE
docs(filters): add dynamic freeleech table

### DIFF
--- a/docs/filters/freeleech.md
+++ b/docs/filters/freeleech.md
@@ -5,45 +5,13 @@ keywords: [autobrr, filters, freeleech]
 pagination_label: Filters - Freeleech
 ---
 
+import Freeleech from '/snippets/freeleech.mdx';
+
 # Freeleech
 
-Not all indexers implemented in autobrr support the freeleech filtering.  
+Not all indexers implemented in autobrr support freeleech filtering.  
 This is due to the indexer simply not announcing freeleech.
 
-To check if you can filter for freeleech, we have put together a list for you to see if you can filter for freeleech.
-Indexers under the Freeleech category only support the freeleech switch in autobrr.  
-Whereas indexers under the freeleech percent category support values in the freeleech percent field.
+This table shows all supported indexers and their freeleech capabilities. This list is updated regularly and automatically.
 
-## Freeleech
-
-- AlphaRatio
-- AnimeBytes
-- Anthelion
-- DanishBytes
-- FileList
-- FunFile
-- GazelleGames
-- HUNO
-- iAnon
-- iPlay
-- IPTorrents
-- MyAnonamouse
-- PassThePopcorn
-- PTFiles
-- Pussytorrents
-- SuperBits
-- TorrentDay
-- TorrentLeech
-- TorrentSeeds
-
-## Freeleech Percent
-
-- All Torznab indexers
-- Aither
-- BeyondHD
-- Locadora
-- LST
-- OnlyEncodes
-- ReelFliX
-- TheDarkCommunity
-- TheOldSchool
+<Freeleech/>


### PR DESCRIPTION
`/docs/filters/freeleech.md` now use the `/snippets/freeleech.mdx` snippet and will always show the supported indexers based on https://github.com/autobrr/autobrr/tree/develop/internal/indexer/definitions