### PR TITLE
Update PSS in freeleech.mdx

### DIFF
--- a/snippets/freeleech.mdx
+++ b/snippets/freeleech.mdx
@@ -18,7 +18,7 @@
 | LST | ✗ | ✓ |
 | MyAnonamouse | ✓ | ✗ |
 | OnlyEncodes | ✗ | ✓ |
-| PrivateSilverScreen | ✓ | ✗ |
+| PrivateSilverScreen | ✗ | ✓ |
 | PTFiles | ✓ | ✗ |
 | PussyTorrents | ✓ | ✗ |
 | ReelFliX | ✗ | ✓ |


### PR DESCRIPTION
Updated PrivateSilverScreen:

According to the logs in autobrr, PSS seems to announce FL as percent, is this correct? E.g: `18:17:05 DBG Category [Movies] Type [WEB-DL] Name [Aliens 1986 1080p AMZN WEB-DL DD+ 5.1 H.265-GRiMM] Resolution [1080p] **Freeleech [0%]** Double Upload [No] Size [5.3 GB] Uploader [GRiMM] Url [https://privatesilverscreen.cc/torrent/download/21074] channel=#announce module=irc network=irc.privatesilverscreen.cc nick=pssBot`