### PR TITLE
swag install does not have allowdeny.conf

### DIFF
--- a/docs/installation/reverse-proxy/swag.md
+++ b/docs/installation/reverse-proxy/swag.md
@@ -41,7 +41,6 @@ server {
 
         include /config/nginx/proxy.conf;
         include /config/nginx/resolver.conf;
-        include /config/nginx/allowdeny.conf;
         set $upstream_app autobrr;
         set $upstream_port 7474;
         set $upstream_proto http;


### PR DESCRIPTION
In my latest install of swag `allowdeny.conf` did not exist.