### PR TITLE
docs: add NZBGet and Shoutrrr mentions, document aria2 support

### DIFF
--- a/docs/configuration/download-clients/dedi.mdx
+++ b/docs/configuration/download-clients/dedi.mdx
@@ -19,6 +19,7 @@ keywords:
     rutorrent,
     transmission,
     porla,
+    aria2,
     sabnzbd,
     nzbget,
     radarr,
@@ -44,6 +45,7 @@ These are the available download clients.
 - rTorrent / ruTorrent
 - Transmission
 - Porla
+- aria2
 - Sabnzbd (Usenet)
 - NZBGet (Usenet)
 - Radarr
@@ -296,6 +298,23 @@ Connects to the Porla web API.
 Some setups also require **Basic Auth** with a username and password, like other clients behind an HTTP-auth proxy.
 
 ## Porla rules {/* #porla-rules */}
+
+You can define some basic rules which can improve your performance for racing etc.
+
+- **Enabled**: Disabled by default.
+- **Max active downloads**: Default 0 (unlimited). Limit the amount of active downloads, to give the maximum amount of bandwidth and disk for the downloads.
+
+## aria2 {/* #aria2 */}
+
+Connects to the aria2 JSON-RPC endpoint.
+
+- Host: `http://localhost:6800`, or `http(s)://domain.ltd/aria2` for reverse-proxied setups
+- RPC secret: `<secret>` (optional, the value of aria2's `--rpc-secret` option; leave empty if aria2 runs without one)
+- TLS: enable for `https://` hosts, with **Skip TLS verification** available for self-signed certificates
+
+Some setups also require **Basic Auth** with a username and password, like other clients behind an HTTP-auth proxy.
+
+## aria2 rules {/* #aria2-rules */}
 
 You can define some basic rules which can improve your performance for racing etc.
 

--- a/docs/filters/actions.mdx
+++ b/docs/filters/actions.mdx
@@ -12,6 +12,7 @@ keywords:
     rTorrent,
     Transmission,
     Porla,
+    aria2,
     SABnzbd,
     NZBGet,
     Radarr,
@@ -55,6 +56,7 @@ The [macro section](../filters/macros.mdx) has been moved to its own page.
 - rTorrent
 - Transmission
 - Porla
+- aria2
 - SABnzbd (Usenet)
 - NZBGet (Usenet)
 - Radarr
@@ -206,6 +208,24 @@ Send to one or multiple local or remote instances of Porla.
 
 - **Limit download and upload speed**: *optional*  
   Takes any integer as a number. Given in `KiB/s`.
+
+### aria2 {/* #aria2 */}
+
+Send to one or multiple local or remote instances of aria2.
+
+#### Available options: {/* #aria2-available-options */}
+
+- **Save Path**: *optional*
+- **Add Paused**: *default false*
+
+#### Limits: {/* #aria2-limits */}
+
+- **Limit download and upload speed**: *optional*  
+  Takes any integer as a number. Given in `KiB/s`.
+- **Ratio limit**: *optional*  
+  Seeding stops when the ratio is reached.
+- **Seed time limit**: *optional*  
+  Given in minutes.
 
 ### SABnzbd / NZBGet {/* #sabnzbd--nzbget */}
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -123,6 +123,7 @@ Available download clients and actions
 - rTorrent / ruTorrent
 - Transmission
 - Porla
+- aria2
 - Sabnzbd (Usenet)
 - NZBGet (Usenet)
 - Sonarr, Radarr, Lidarr, Readarr and Whisparr (pushes releases directly to them and gets in the early swarm, instead of getting them via RSS when it's already over)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -154,7 +154,7 @@ function Hero() {
                 <strong>100+</strong> indexers
               </span>
               <span>
-                <strong>7</strong> download clients
+                <strong>8</strong> download clients
               </span>
               <span>
                 <strong>5</strong> *arr integrations
@@ -232,12 +232,12 @@ const FEATURES = [
   {
     icon: <TbPlugConnected size={20} />,
     title: "Works with your setup",
-    body: "Push to qBittorrent, Deluge, Transmission, rTorrent, Porla or SABnzbd, or route releases through Sonarr and Radarr.",
+    body: "Push to qBittorrent, Deluge, Transmission, rTorrent, Porla, SABnzbd or NZBGet, or route releases through Sonarr and Radarr.",
   },
   {
     icon: <MdOutlineNotificationsActive size={20} />,
     title: "Notifications and hooks",
-    body: "Get a ping on Discord, Telegram, Pushover or ntfy for every push, and trigger webhooks or scripts on match.",
+    body: "Get a ping on Discord, Telegram, Pushover, Gotify, Shoutrrr or ntfy for every push, and trigger webhooks or scripts on match.",
   },
   {
     icon: <FiPackage size={20} />,
@@ -422,6 +422,7 @@ const STACK = [
       "ruTorrent",
       "Porla",
       "SABnzbd",
+      "NZBGet",
     ],
   },
   {
@@ -434,7 +435,7 @@ const STACK = [
   },
   {
     label: "Notifications",
-    items: ["Discord", "Notifiarr", "Telegram", "Pushover", "Gotify", "ntfy"],
+    items: ["Discord", "Notifiarr", "Telegram", "Pushover", "Gotify", "Shoutrrr", "ntfy"],
   },
 ];
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -154,7 +154,7 @@ function Hero() {
                 <strong>100+</strong> indexers
               </span>
               <span>
-                <strong>8</strong> download clients
+                <strong>9</strong> download clients
               </span>
               <span>
                 <strong>5</strong> *arr integrations
@@ -232,7 +232,7 @@ const FEATURES = [
   {
     icon: <TbPlugConnected size={20} />,
     title: "Works with your setup",
-    body: "Push to qBittorrent, Deluge, Transmission, rTorrent, Porla, SABnzbd or NZBGet, or route releases through Sonarr and Radarr.",
+    body: "Push to qBittorrent, Deluge, Transmission, rTorrent, Porla, aria2, SABnzbd or NZBGet, or route releases through Sonarr and Radarr.",
   },
   {
     icon: <MdOutlineNotificationsActive size={20} />,
@@ -421,6 +421,7 @@ const STACK = [
       "rTorrent",
       "ruTorrent",
       "Porla",
+      "aria2",
       "SABnzbd",
       "NZBGet",
     ],


### PR DESCRIPTION
Add NZBGet and Shoutrrr mentions on the homepage, plus Gotify in one place.

As both, NZBGet and Shoutrrr are supported in autobrr.

as per [feat(notifications): add Shoutrrr support - #1326](https://github.com/autobrr/autobrr/pull/1326)
and [feat(clients): add NZBGet support - #2370](https://github.com/autobrr/autobrr/pull/2370)

Not sure if qui should be mentionned as well, as ruTorrent is mentionned too. Unless it's already taken in account via "qBittorrent".