### PR TITLE
docs: add missing release notes for v1.82.0–v1.83.0

### DIFF
--- a/blog/2026-07-13-v1.82.0/index.md
+++ b/blog/2026-07-13-v1.82.0/index.md
@@ -1,0 +1,32 @@
+---
+slug: v1.82.0
+title: v1.82.0
+authors: [rogerrabbit]
+---
+## Changelog
+
+### New Features
+
+* feat(config): align defaults with README.md ([#2509](https://github.com/autobrr/autobrr/pull/2509)) ([@Nomsplease](https://github.com/Nomsplease))
+* feat(indexers):  definition v2 format ([#2502](https://github.com/autobrr/autobrr/pull/2502)) ([@zze0s](https://github.com/zze0s))
+* feat(indexers): DigitalCore add alt url ([#2514](https://github.com/autobrr/autobrr/pull/2514)) ([@zze0s](https://github.com/zze0s))
+* feat(indexers): add DasUnerwartete ([#2493](https://github.com/autobrr/autobrr/pull/2493)) ([@zze0s](https://github.com/zze0s))
+* feat(indexers): make NickServ optional and channel password required for BIT-HDTV ([#2498](https://github.com/autobrr/autobrr/pull/2498)) ([@arjunrn](https://github.com/arjunrn))
+* feat(irc): optionally skip message cleaning ([#2518](https://github.com/autobrr/autobrr/pull/2518)) ([@zze0s](https://github.com/zze0s))
+* feat(irc): resilient connection & channel handling with improved auto-recover ([#1709](https://github.com/autobrr/autobrr/pull/1709)) ([@zze0s](https://github.com/zze0s))
+* feat(macros): add MetaTMDB field ([#2517](https://github.com/autobrr/autobrr/pull/2517)) ([@zze0s](https://github.com/zze0s))
+* feat(releases): support type in release search ([#2512](https://github.com/autobrr/autobrr/pull/2512)) ([@nuxencs](https://github.com/nuxencs))
+
+### Bug fixes
+
+* fix(indexers): DasUnerwartete key settings and NickServ auth ([#2516](https://github.com/autobrr/autobrr/pull/2516)) ([@martylukyy](https://github.com/martylukyy))
+* fix(irc): announce processor channel lookup order ([#2510](https://github.com/autobrr/autobrr/pull/2510)) ([@zze0s](https://github.com/zze0s))
+
+### Other work
+
+* build(deps): add workflow to update language versions ([#2499](https://github.com/autobrr/autobrr/pull/2499)) ([@zze0s](https://github.com/zze0s))
+* build(deps): bump Go to 1.26 ([#2497](https://github.com/autobrr/autobrr/pull/2497)) ([@zze0s](https://github.com/zze0s))
+* build(deps): bump rls to v0.8.1 ([#2496](https://github.com/autobrr/autobrr/pull/2496)) ([@zze0s](https://github.com/zze0s))
+* build(deps): bump the npm group in /web with 18 updates ([#2501](https://github.com/autobrr/autobrr/pull/2501)) ([@dependabot](https://github.com/dependabot)[bot])
+* chore: update PR template and add agent guidelines ([#2513](https://github.com/autobrr/autobrr/pull/2513)) ([@zze0s](https://github.com/zze0s))
+* refactor(backend): return structs and accept interfaces ([#2504](https://github.com/autobrr/autobrr/pull/2504)) ([@zze0s](https://github.com/zze0s))

--- a/blog/2026-07-15-v1.82.1/index.md
+++ b/blog/2026-07-15-v1.82.1/index.md
@@ -1,0 +1,10 @@
+---
+slug: v1.82.1
+title: v1.82.1
+authors: [rogerrabbit]
+---
+## Changelog
+
+### Bug fixes
+
+* fix(indexers): GGn IRC parser ([#2519](https://github.com/autobrr/autobrr/pull/2519)) ([@zze0s](https://github.com/zze0s))

--- a/blog/2026-07-27-v1.83.0/index.md
+++ b/blog/2026-07-27-v1.83.0/index.md
@@ -1,0 +1,36 @@
+---
+slug: v1.83.0
+title: v1.83.0
+authors: [rogerrabbit]
+---
+## Changelog
+
+### New Features
+
+* feat(clients): add aria2 support ([#2548](https://github.com/autobrr/autobrr/pull/2548)) ([@zze0s](https://github.com/zze0s))
+* feat(filters): batch external filter lookup ([#2546](https://github.com/autobrr/autobrr/pull/2546)) ([@zze0s](https://github.com/zze0s))
+* feat(filters): update Perfect FLAC to match RED/OPS definition ([#2534](https://github.com/autobrr/autobrr/pull/2534)) ([@zze0s](https://github.com/zze0s))
+* feat(indexers): update TorrentHR for UNIT3D migration ([#2531](https://github.com/autobrr/autobrr/pull/2531)) ([@chorijan](https://github.com/chorijan))
+* feat(lists): add Whisparr v3 support and fix list refresh panic ([#2544](https://github.com/autobrr/autobrr/pull/2544)) ([@zze0s](https://github.com/zze0s))
+* feat(logs): add trace id from announce to action and improved structured logging ([#2533](https://github.com/autobrr/autobrr/pull/2533)) ([@zze0s](https://github.com/zze0s))
+* feat(releases): keep torrent in memory and only write a file when needed ([#840](https://github.com/autobrr/autobrr/pull/840)) ([@KyleSanderson](https://github.com/KyleSanderson))
+* feat(releases): replace anacrolix/torrent with autobrr/go-torrent ([#2535](https://github.com/autobrr/autobrr/pull/2535)) ([@zze0s](https://github.com/zze0s))
+* feat(tests): implement E2E test suite ([#1099](https://github.com/autobrr/autobrr/pull/1099)) ([@zze0s](https://github.com/zze0s))
+
+### Bug fixes
+
+* fix(actions): treat invalid arr download client responses as errors ([#2222](https://github.com/autobrr/autobrr/pull/2222)) ([@s0up4200](https://github.com/s0up4200))
+* fix(docs): parse v2 definitions in indexer docs generator ([#2542](https://github.com/autobrr/autobrr/pull/2542)) ([@zze0s](https://github.com/zze0s))
+* fix(feeds): empty imdb id handling ([#2539](https://github.com/autobrr/autobrr/pull/2539)) ([@zze0s](https://github.com/zze0s))
+* fix(feeds): resolve magnet links from torznab magneturl ([#2547](https://github.com/autobrr/autobrr/pull/2547)) ([@zze0s](https://github.com/zze0s))
+* fix(feeds): stagger scheduled runs and store cache items synchronously ([#2271](https://github.com/autobrr/autobrr/pull/2271)) ([@zze0s](https://github.com/zze0s))
+* fix(irc): attempt NickServ IDENTIFY with account on failure ([#2540](https://github.com/autobrr/autobrr/pull/2540)) ([@zze0s](https://github.com/zze0s))
+* fix(irc): keep live updates in sync with history when skipping message cleaning ([#2538](https://github.com/autobrr/autobrr/pull/2538)) ([@zze0s](https://github.com/zze0s))
+* fix(web): replace HeadlessUI slide-overs with non-modal Base UI drawers ([#2537](https://github.com/autobrr/autobrr/pull/2537)) ([@zze0s](https://github.com/zze0s))
+
+### Other work
+
+* build(deps): bump actions/setup-python from 6 to 7 in the github group ([#2541](https://github.com/autobrr/autobrr/pull/2541)) ([@dependabot](https://github.com/dependabot)[bot])
+* build(deps): bump the github group with 2 updates ([#2529](https://github.com/autobrr/autobrr/pull/2529)) ([@dependabot](https://github.com/dependabot)[bot])
+* perf(indexers): cache announce templates and stop allocating errors on misses ([#2545](https://github.com/autobrr/autobrr/pull/2545)) ([@zze0s](https://github.com/zze0s))
+* refactor(logger): drop the wrapper and improve log sanitizing  ([#2543](https://github.com/autobrr/autobrr/pull/2543)) ([@zze0s](https://github.com/zze0s))

--- a/update_release_notes.py
+++ b/update_release_notes.py
@@ -80,7 +80,8 @@ def git_operations():
         branch = repo.create_head(branch_name)
         repo.git.checkout(branch_name)
 
-    print(f"::set-output name=branch::{branch_name}")
+    with open(os.environ.get("GITHUB_OUTPUT", "/dev/null"), "a") as f:
+        f.write(f"branch={branch_name}\n")
     return branch
 
 def main():


### PR DESCRIPTION
Adds the blog entries the automation missed (v1.82.0, v1.82.1, v1.83.0), and swaps the deprecated `::set-output` for `$GITHUB_OUTPUT` in the update script. The automation itself is fixed in autobrr/autobrr — the trigger workflow's tag condition never matched, so the dispatch never fired.