### PR TITLE
docs: Bytesized one-click and rootless Docker install options

### DIFF
--- a/docs/installation/seedbox.mdx
+++ b/docs/installation/seedbox.mdx
@@ -93,6 +93,14 @@ The scripts require some input but do most of the work.
 
 ### Bytesized
 
+:::info
+
+Bytesized also offers autobrr as a one-click install from its panel, and its appboxes
+support rootless Docker, so the [Docker](./docker.mdx) installation method works there
+as well. The script below remains a supported way to install and update.
+
+:::
+
 #### Installation & Update
 
 ```shell


### PR DESCRIPTION
Small accuracy update to the Bytesized section of the seedbox installation page.

Bytesized Hosting (bytesized-hosting.com) now ships autobrr as a one-click install in its panel, and its appboxes include rootless Docker, so the Docker installation method from these docs works there too. The existing install script remains supported and unchanged; this just adds an info admonition so users know all three routes.

Happy to adjust wording. I run Bytesized, so flagging that openly.